### PR TITLE
Adds a release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    branches:
+    - master
+  release:
+    types:
+    - created
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish
+      if: success() && startsWith(github.ref, 'refs/tags/releases/')
+      run: npm run publish
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "lint": "tslint -p ./",
     "package": "vsce package",
     "watch": "tsc -watch -p ./",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "publish": "vsce publish"
   }
 }


### PR DESCRIPTION
@stanleygjones Now we just need to set up the VSCE_PAT secret as described in https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions-automated-publishing and you shouldn't need to manually publish new version of the plugin anymore.