### PR TITLE
Add basic code formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/which": "^2.0.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-motoko": "^0.1.1",
+        "prettier-plugin-motoko": "^0.1.2",
         "vscode-languageclient": "^7.0.0",
         "which": "2.0.2"
       },
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/prettier-plugin-motoko": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.1.tgz",
-      "integrity": "sha512-62pQulOjAOkI/qwSsyX0Y8cGmE9Lys6k6SWuOKZJRECnwkpbaOzjrId87NuYs5oqegY1CCSAymcOGp/tn7LsBQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.2.tgz",
+      "integrity": "sha512-nXnSCXwVobUG85E3OPpl5n3h3fgttQhMgH7pB88BjyuyVYIb0qJhF/Q80/kgyfgNFzm86H6vhEqawoyu6cHEXQ==",
       "peerDependencies": {
         "prettier": "^2.7"
       }
@@ -1989,9 +1989,9 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-plugin-motoko": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.1.tgz",
-      "integrity": "sha512-62pQulOjAOkI/qwSsyX0Y8cGmE9Lys6k6SWuOKZJRECnwkpbaOzjrId87NuYs5oqegY1CCSAymcOGp/tn7LsBQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.2.tgz",
+      "integrity": "sha512-nXnSCXwVobUG85E3OPpl5n3h3fgttQhMgH7pB88BjyuyVYIb0qJhF/Q80/kgyfgNFzm86H6vhEqawoyu6cHEXQ==",
       "requires": {}
     },
     "pump": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/which": "^2.0.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-motoko": "^0.1.2",
+        "prettier-plugin-motoko": "^0.1.3",
         "vscode-languageclient": "^7.0.0",
         "which": "2.0.2"
       },
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/prettier-plugin-motoko": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.2.tgz",
-      "integrity": "sha512-nXnSCXwVobUG85E3OPpl5n3h3fgttQhMgH7pB88BjyuyVYIb0qJhF/Q80/kgyfgNFzm86H6vhEqawoyu6cHEXQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.3.tgz",
+      "integrity": "sha512-UxEN2XCod9sYDHc1Aas1o7gHnHO29VBOiDsPqyL36AMgF6TvRb18DcNtxVWGYmphnFJZTkudwf6GBsRB6gBNIw==",
       "peerDependencies": {
         "prettier": "^2.7"
       }
@@ -1989,9 +1989,9 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-plugin-motoko": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.2.tgz",
-      "integrity": "sha512-nXnSCXwVobUG85E3OPpl5n3h3fgttQhMgH7pB88BjyuyVYIb0qJhF/Q80/kgyfgNFzm86H6vhEqawoyu6cHEXQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.3.tgz",
+      "integrity": "sha512-UxEN2XCod9sYDHc1Aas1o7gHnHO29VBOiDsPqyL36AMgF6TvRb18DcNtxVWGYmphnFJZTkudwf6GBsRB6gBNIw==",
       "requires": {}
     },
     "pump": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/which": "^2.0.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-motoko": "^0.1.0",
+        "prettier-plugin-motoko": "^0.1.1",
         "vscode-languageclient": "^7.0.0",
         "which": "2.0.2"
       },
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/prettier-plugin-motoko": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.0.tgz",
-      "integrity": "sha512-qD7uIYrNznPLeJNOmQt083J/ZJCSKxrCBK//95vfyPqW+iHictxRBY05zmZf9XpLExvTHpeVYy0zculbfsL21g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.1.tgz",
+      "integrity": "sha512-62pQulOjAOkI/qwSsyX0Y8cGmE9Lys6k6SWuOKZJRECnwkpbaOzjrId87NuYs5oqegY1CCSAymcOGp/tn7LsBQ==",
       "peerDependencies": {
         "prettier": "^2.7"
       }
@@ -1989,9 +1989,9 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-plugin-motoko": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.0.tgz",
-      "integrity": "sha512-qD7uIYrNznPLeJNOmQt083J/ZJCSKxrCBK//95vfyPqW+iHictxRBY05zmZf9XpLExvTHpeVYy0zculbfsL21g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.1.tgz",
+      "integrity": "sha512-62pQulOjAOkI/qwSsyX0Y8cGmE9Lys6k6SWuOKZJRECnwkpbaOzjrId87NuYs5oqegY1CCSAymcOGp/tn7LsBQ==",
       "requires": {}
     },
     "pump": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/which": "^2.0.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-motoko": "^0.0.6",
+        "prettier-plugin-motoko": "^0.1.0",
         "vscode-languageclient": "^7.0.0",
         "which": "2.0.2"
       },
@@ -877,11 +877,11 @@
       }
     },
     "node_modules/prettier-plugin-motoko": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.0.6.tgz",
-      "integrity": "sha512-zdoQF3Bb+pkk/i8QHeSSPGcdwYoRu7zB7YKCAihpFVt38nbmiUFEb75vjBhK+yHhw//kbebQx5DXfdr7X5vyJg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.0.tgz",
+      "integrity": "sha512-qD7uIYrNznPLeJNOmQt083J/ZJCSKxrCBK//95vfyPqW+iHictxRBY05zmZf9XpLExvTHpeVYy0zculbfsL21g==",
       "peerDependencies": {
-        "prettier": "^2"
+        "prettier": "^2.7"
       }
     },
     "node_modules/pump": {
@@ -1989,9 +1989,9 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-plugin-motoko": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.0.6.tgz",
-      "integrity": "sha512-zdoQF3Bb+pkk/i8QHeSSPGcdwYoRu7zB7YKCAihpFVt38nbmiUFEb75vjBhK+yHhw//kbebQx5DXfdr7X5vyJg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.1.0.tgz",
+      "integrity": "sha512-qD7uIYrNznPLeJNOmQt083J/ZJCSKxrCBK//95vfyPqW+iHictxRBY05zmZf9XpLExvTHpeVYy0zculbfsL21g==",
       "requires": {}
     },
     "pump": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-motoko",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-motoko",
-      "version": "0.3.11",
+      "version": "0.4.0",
       "dependencies": {
         "@types/which": "^2.0.0",
         "prettier": "^2.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,26 @@
 {
   "name": "vscode-motoko",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-motoko",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@types/which": "^2.0.0",
+        "prettier": "^2.7.1",
+        "prettier-plugin-motoko": "^0.0.6",
         "vscode-languageclient": "^7.0.0",
         "which": "2.0.2"
       },
       "devDependencies": {
         "@types/node": "^14.14.30",
+        "@types/prettier": "^2.7.0",
         "@types/vscode": "^1.53.0",
-        "prettier": "2.2.1",
+        "rimraf": "^3.0.2",
         "typescript": "^4.1.5",
-        "vsce": "^2.10.0"
+        "vsce": "^2.10.2"
       },
       "engines": {
         "vscode": "^1.53.0"
@@ -27,6 +30,12 @@
       "version": "14.14.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
       "integrity": "sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==",
+      "dev": true
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -854,15 +863,25 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-      "dev": true,
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-motoko": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.0.6.tgz",
+      "integrity": "sha512-zdoQF3Bb+pkk/i8QHeSSPGcdwYoRu7zB7YKCAihpFVt38nbmiUFEb75vjBhK+yHhw//kbebQx5DXfdr7X5vyJg==",
+      "peerDependencies": {
+        "prettier": "^2"
       }
     },
     "node_modules/pump": {
@@ -1180,9 +1199,9 @@
       "dev": true
     },
     "node_modules/vsce": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
-      "integrity": "sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.2.tgz",
+      "integrity": "sha512-DZdD3B7rfANNefBpyzE7g1IQkEWuJ/0KoCrimMreOYW6XKfoZSMouFNBh26Cpk9kNZsjZqxTc1/ckLouDZIw/Q==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
@@ -1334,6 +1353,12 @@
       "version": "14.14.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
       "integrity": "sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
       "dev": true
     },
     "@types/vscode": {
@@ -1959,10 +1984,15 @@
       }
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-      "dev": true
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+    },
+    "prettier-plugin-motoko": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.0.6.tgz",
+      "integrity": "sha512-zdoQF3Bb+pkk/i8QHeSSPGcdwYoRu7zB7YKCAihpFVt38nbmiUFEb75vjBhK+yHhw//kbebQx5DXfdr7X5vyJg==",
+      "requires": {}
     },
     "pump": {
       "version": "3.0.0",
@@ -2185,9 +2215,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
-      "integrity": "sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.2.tgz",
+      "integrity": "sha512-DZdD3B7rfANNefBpyzE7g1IQkEWuJ/0KoCrimMreOYW6XKfoZSMouFNBh26Cpk9kNZsjZqxTc1/ckLouDZIw/Q==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "dependencies": {
     "@types/which": "^2.0.0",
     "prettier": "^2.7.1",
-    "prettier-plugin-motoko": "^0.1.2",
+    "prettier-plugin-motoko": "^0.1.3",
     "vscode-languageclient": "^7.0.0",
     "which": "2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "dependencies": {
     "@types/which": "^2.0.0",
     "prettier": "^2.7.1",
-    "prettier-plugin-motoko": "^0.1.0",
+    "prettier-plugin-motoko": "^0.1.1",
     "vscode-languageclient": "^7.0.0",
     "which": "2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "dependencies": {
     "@types/which": "^2.0.0",
     "prettier": "^2.7.1",
-    "prettier-plugin-motoko": "^0.1.1",
+    "prettier-plugin-motoko": "^0.1.2",
     "vscode-languageclient": "^7.0.0",
     "which": "2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-motoko",
   "displayName": "Motoko",
   "description": "Motoko language support",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "publisher": "dfinity-foundation",
   "repository": "https://github.com/dfinity/vscode-motoko",
   "engines": {
@@ -81,6 +81,15 @@
           "type": "string",
           "default": "",
           "description": "Additional arguments to pass to the language server when running in a non-dfx project"
+        },
+        "motoko.formatter": {
+          "type": "string",
+          "default": "prettier",
+          "enum": [
+            "none",
+            "prettier"
+          ],
+          "description": "Use the selected Motoko code formatter"
         }
       }
     },
@@ -104,22 +113,25 @@
   "main": "./out/extension",
   "dependencies": {
     "@types/which": "^2.0.0",
+    "prettier": "^2.7.1",
+    "prettier-plugin-motoko": "^0.0.6",
     "vscode-languageclient": "^7.0.0",
     "which": "2.0.2"
   },
   "devDependencies": {
     "@types/node": "^14.14.30",
+    "@types/prettier": "^2.7.0",
     "@types/vscode": "^1.53.0",
-    "prettier": "2.2.1",
+    "rimraf": "^3.0.2",
     "typescript": "^4.1.5",
-    "vsce": "^2.10.0"
+    "vsce": "^2.10.2"
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
-    "lint": "tslint -p ./",
+    "compile": "rimraf ./out && tsc -p .",
+    "lint": "tslint -p .",
     "package": "vsce package",
-    "watch": "tsc -watch -p ./",
+    "watch": "tsc -watch -p .",
     "format": "prettier --write .",
     "publish": "vsce publish"
   }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "dependencies": {
     "@types/which": "^2.0.0",
     "prettier": "^2.7.1",
-    "prettier-plugin-motoko": "^0.0.6",
+    "prettier-plugin-motoko": "^0.1.0",
     "vscode-languageclient": "^7.0.0",
     "which": "2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-motoko",
   "displayName": "Motoko",
   "description": "Motoko language support",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "publisher": "dfinity-foundation",
   "repository": "https://github.com/dfinity/vscode-motoko",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { workspace, ExtensionContext, window, commands } from "vscode";
+import { workspace, ExtensionContext, window, commands, languages, TextDocument, TextEdit } from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 import * as which from "which";
@@ -8,6 +8,7 @@ import {
   LanguageClientOptions,
   ServerOptions,
 } from "vscode-languageclient/node";
+import { formatDocument } from "./formatter";
 
 const config = workspace.getConfiguration("motoko");
 
@@ -17,6 +18,12 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand("motoko.startService", startServer)
   );
+  context.subscriptions.push(
+    languages.registerDocumentFormattingEditProvider('motoko', {
+      provideDocumentFormattingEdits(document: TextDocument): TextEdit[] {
+        return formatDocument(document, context);
+      },
+    }));
   startServer();
 }
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,60 @@
+import * as prettier from "prettier";
+import * as vscode from "vscode";
+import * as path from "path";
+import { getCurrentWorkspaceRootFsPath } from "./utils";
+
+export function formatDocument(
+  document: vscode.TextDocument,
+  context: vscode.ExtensionContext
+): vscode.TextEdit[] {
+  const formatter = vscode.workspace
+    .getConfiguration("motoko")
+    .get<string>("formatter");
+  if (formatter === "prettier") {
+    const rootPath = getCurrentWorkspaceRootFsPath();
+    if (rootPath) {
+      const ignoreOptions = {
+        ignorePath: path.join(rootPath, ".prettierignore"),
+      };
+      const fileInfo = prettier.getFileInfo.sync(
+        document.uri.fsPath,
+        ignoreOptions
+      );
+      if (!fileInfo.ignored) {
+        const source = document.getText();
+
+        const pluginPath = path.join(
+          context.extensionPath,
+          "node_modules",
+          "prettier-plugin-motoko"
+        );
+        const config = prettier.resolveConfig.sync(
+          document.uri.fsPath /* , options */
+        );
+        if (config !== null) {
+          prettier.clearConfigCache();
+        }
+        const options: prettier.Options = {
+          filepath: document.fileName,
+          // parser: "motoko-tt-parse",
+          pluginSearchDirs: [context.extensionPath],
+          plugins: [pluginPath],
+          ...(config || {}),
+        };
+        // Object.assign(options, config);
+        const firstLine = document.lineAt(0);
+        const lastLine = document.lineAt(document.lineCount - 1);
+        const fullTextRange = new vscode.Range(
+          firstLine.range.start,
+          lastLine.range.end
+        );
+        const formatted = prettier.format(source, options);
+        if (!formatted) {
+          return [];
+        }
+        return [vscode.TextEdit.replace(fullTextRange, formatted)];
+      }
+    }
+  }
+  return [];
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export function getCurrentWorkspaceRootFsPath() : string | undefined {
+    return getCurrentWorkspaceRootFolder()?.uri.fsPath;
+}
+
+export function getCurrentWorkspaceRootFolder() : vscode.WorkspaceFolder | undefined {
+    var editor = vscode.window.activeTextEditor!;
+    const currentDocument = editor.document.uri;
+    return vscode.workspace.getWorkspaceFolder(currentDocument);
+}

--- a/syntaxes/Major.tmLanguage
+++ b/syntaxes/Major.tmLanguage
@@ -737,7 +737,7 @@
 					<key>comment</key>
 					<string>statement keyword</string>
 					<key>match</key>
-					<string>\b(assert|break|case|continue|default|debug|debug_show|else|if|ignore|in|for|label|return|switch|while|loop|try|throw|to_candid|from_candid|with)\b</string>
+					<string>\b(assert|break|case|continue|default|debug|debug_show|else|if|ignore|in|for|label|return|switch|while|loop|try|throw|catch|do|to_candid|from_candid|with)\b</string>
 					<key>name</key>
 					<string>keyword.statement.motoko</string>
 				</dict>


### PR DESCRIPTION
This PR adds a custom Motoko code formatter which uses [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko) under the hood. It's possible to customize the formatter for individual Motoko projects using a [`.prettierrc` config file](https://prettier.io/docs/en/configuration.html). 

Although this functionality is also supported via the official [Prettier VS Code extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), this integrated formatter will automatically update with the VS Code extension (compared to having to manually bump NPM dependencies otherwise). 

The formatter itself is a [work in progress](https://github.com/dfinity/prettier-plugin-motoko/issues/1). That being said, I'm hoping to get this out to users as early as possible so that we can start prioritizing features based on feedback. 