### PR TITLE
Show 'mo-ide' prompt only when language server is available on path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,20 +37,28 @@ export function startServer() {
     return launchDfxProject(dfxConfig);
   }
 
-  const prompt = `We failed to detect a dfx project for this Motoko file. What file do you want to use as an entry point?`;
-  const currentDocument = window.activeTextEditor?.document?.fileName;
-
-  window.showInputBox({ prompt, value: currentDocument }).then((entryPoint) => {
-    if (entryPoint) {
-      const serverCommand = {
-        command: config.standaloneBinary,
-        args: ["--canister-main", entryPoint]
-          .concat(vesselArgs())
-          .concat(config.standaloneArguments.split(" ")),
-      };
-      launchClient({ run: serverCommand, debug: serverCommand });
+  // Check if `mo-ide` exists
+  fs.access(config.standaloneBinary, fs.constants.F_OK, (err) => {
+    if(err) {
+      console.error(err.message);
+      return;
     }
-  });
+
+    const prompt = `There doesn't seem to be a dfx project for this Motoko file. What file do you want to use as an entry point?`;
+    const currentDocument = window.activeTextEditor?.document?.fileName;
+
+    window.showInputBox({ prompt, value: currentDocument }).then((entryPoint) => {
+      if (entryPoint) {
+        const serverCommand = {
+          command: config.standaloneBinary,
+          args: ["--canister-main", entryPoint]
+            .concat(vesselArgs())
+            .concat(config.standaloneArguments.split(" ")),
+        };
+        launchClient({ run: serverCommand, debug: serverCommand });
+      }
+    });
+  })
 }
 
 function launchDfxProject(dfxConfig: DfxConfig) {


### PR DESCRIPTION
The VS Code extension currently has a tendency to nag the user about choosing a `mo-ide` entry point whenever `dfx.json` is missing from the project workspace... every single time the extension finishes loading... regardless of whether `mo-ide` is even available on your path. 

This PR hides the prompt if the user-configured `mo-ide` file is missing on your file system, which was probably the original intended behavior for this feature. 

Before looking into how this was implemented, I expected this fix to involve a partial rewrite of the extension. However, it turns out there was a simple, elegant solution. Hooray!