### PR TITLE
Use 'published' release type in GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   release:
     types:
-    - created
+    - published
 
 jobs:
   publish:


### PR DESCRIPTION
Replaces 'created' with 'published' in the release workflow ([relevant StackOverflow question](https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published)).
