### PR TITLE
Improvements to new language server ("TS LS")

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@
 [![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/dfinity-foundation.vscode-motoko?color=brightgreen&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/dfinity/prettier-plugin-motoko/issues)
 
+## Recent Changes
+
+We are currently in the process of revamping the Motoko VS Code extension.
+
+Projects using `dfx >= 0.11.1` use a new, experimental language server.
+
+To continue using the original language server, you can modify your `dfx.json` file to use version `0.11.0` or earlier:
+
+```json
+{
+  "dfx": "0.11.0",
+  ...
+}
+```
+
+If you encounter any bugs, please [open a GitHub issue](https://github.com/dfinity/vscode-motoko/issues) with steps to reproduce so that we can fix the problem for everyone. 
+
 ## Features
 
 - Syntax highlighting

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ To continue using the original language server, you can modify your `dfx.json` f
 
 ```json
 {
-  "dfx": "0.11.0",
-  ...
+  "dfx": "0.11.0"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-motoko",
   "displayName": "Motoko",
   "description": "Motoko language support",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "dfinity-foundation",
   "repository": "https://github.com/dfinity/vscode-motoko",
   "engines": {
@@ -47,10 +47,10 @@
           "default": "dfx",
           "description": "Location of the dfx executable"
         },
-        "motoko.legacyDfxSupport": {
+        "motoko.legacyLanguageServer": {
           "scope": "resource",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Uses the legacy OCaml language server when a `dfx.json` file is available."
         },
         "motoko.maxNumberOfProblems": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
         "motoko.legacyLanguageServer": {
           "scope": "resource",
           "type": "boolean",
-          "default": false,
-          "description": "Uses the legacy OCaml language server when a `dfx.json` file is available."
+          "default": true,
+          "description": "Uses the legacy OCaml language server when `dfx <= 0.11.0`."
         },
         "motoko.maxNumberOfProblems": {
           "scope": "resource",
@@ -108,7 +108,7 @@
     "commands": [
       {
         "command": "motoko.startService",
-        "title": "Motoko: Restart language service"
+        "title": "Motoko: Restart language server"
       }
     ],
     "jsonValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,8 +180,8 @@ function getDfxConfig(): DfxConfig | undefined {
                 .readFileSync(path.join(wsf[0].uri.fsPath, 'dfx.json'))
                 .toString('utf8'),
         );
-        // Require TS language server for `dfx >= 0.11.1`
-        if (dfxConfig.dfx >= '0.11.1') {
+        // Require TS language server for newer versions of `dfx`
+        if (!dfxConfig?.dfx || dfxConfig.dfx >= '0.11.1') {
             return;
         }
         return dfxConfig;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,7 @@ type DfxConfig = {
 };
 
 function getDfxConfig(): DfxConfig | undefined {
-    if (!config.get('legacyDfxSupport')) {
+    if (!config.get('legacyLanguageServer')) {
         return;
     }
     const wsf = workspace.workspaceFolders;


### PR DESCRIPTION
- Support Vessel packages in projects without a `dfx.json` file
- Add "Restart Motoko language service" functionality for the TS LS
- Automatically use the TS LS when `dfx >= 0.11.1` or if no `dfx` version is specified
- Update the readme with information about the new language server
