### PR TITLE
Remove angle brackets from auto-closing pairs

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,33 +1,33 @@
 {
-  "comments": {
-    // symbol used for single line comment. Remove this entry if your language does not support line comments
-    "lineComment": "//",
-    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-    "blockComment": ["/*", "*/"]
-  },
-  // symbols used as brackets
-  "brackets": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["<", ">"]
-  ],
-  // symbols that are auto closed when typing
-  "autoClosingPairs": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["\"", "\""],
-    ["'", "'"],
-    ["<", ">"]
-  ],
-  // symbols that that can be used to surround a selection
-  "surroundingPairs": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["\"", "\""],
-    ["'", "'"],
-    ["<", ">"]
-  ]
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//",
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": ["/*", "*/"]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+        // ["<", ">"]
+    ],
+    // symbols that that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"],
+        ["<", ">"]
+    ]
 }


### PR DESCRIPTION
Removes the auto-closing behavior when typing `<`, since this often gets in the way of using the `<` or `<=` comparison operators. This simplified behavior is also more consistent with other languages in VS Code. 