### PR TITLE
Propagate type checking from currently open files and `dfx.json` entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,6 @@
 [![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/dfinity-foundation.vscode-motoko?color=brightgreen&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/dfinity/prettier-plugin-motoko/issues)
 
-## Recent Changes
-
-We are currently in the process of revamping the Motoko VS Code extension.
-
-Projects using `dfx >= 0.11.1` use a new, experimental language server.
-
-To continue using the original language server, you can modify your `dfx.json` file to use version `0.11.0` or earlier:
-
-```json
-{
-  "dfx": "0.11.0"
-}
-```
-
-If you encounter any bugs, please [open a GitHub issue](https://github.com/dfinity/vscode-motoko/issues) with steps to reproduce so that we can fix the problem for everyone. 
-
 ## Features
 
 - Syntax highlighting
@@ -51,6 +35,22 @@ Get this extension through the [Visual Studio Marketplace](https://marketplace.v
 - `motoko.standaloneBinary`: The location of the `mo-ide` binary (when running in a non-dfx project)
 - `motoko.formatter`: The formatter used by the extension
 - `motoko.legacyDfxSupport`: Uses legacy `dfx`-dependent features when a `dfx.json` file is available
+
+## Recent Changes
+
+We are currently in the process of revamping the Motoko VS Code extension.
+
+Projects using `dfx >= 0.11.1` use a new, experimental language server.
+
+To continue using the original language server, you can modify your `dfx.json` file to use version `0.11.0` or earlier:
+
+```json
+{
+  "dfx": "0.11.0"
+}
+```
+
+If you encounter any bugs, please [open a GitHub issue](https://github.com/dfinity/vscode-motoko/issues) with steps to reproduce so that we can fix the problem for everyone. 
 
 ## Contributing
 

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,33 +1,33 @@
 {
-  "comments": {
-    // symbol used for single line comment. Remove this entry if your language does not support line comments
-    "lineComment": "//",
-    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-    "blockComment": ["/*", "*/"]
-  },
-  // symbols used as brackets
-  "brackets": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["<", ">"]
-  ],
-  // symbols that are auto closed when typing
-  "autoClosingPairs": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["\"", "\""],
-    ["'", "'"],
-    ["<", ">"]
-  ],
-  // symbols that that can be used to surround a selection
-  "surroundingPairs": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["\"", "\""],
-    ["'", "'"],
-    ["<", ">"]
-  ]
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//",
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": ["/*", "*/"]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+        // ["<", ">"]
+    ],
+    // symbols that that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"],
+        ["<", ">"]
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-motoko",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-motoko",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "fast-glob": "^3.2.11",
         "motoko": "^2.0.10",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export function startServer(context: ExtensionContext) {
             if (err) {
                 console.log(err.message);
 
-                // Launch TypeScript language server
+                // Launch cross-platform language server
                 const module = context.asAbsolutePath(
                     path.join('out', 'server', 'server.js'),
                 );

--- a/src/server/preprocessMotoko.ts
+++ b/src/server/preprocessMotoko.ts
@@ -1,0 +1,20 @@
+// // Hack: use a special package name to load sibling canisters from `dfx.json`
+// const canisterPackagePrefix = '_'.repeat('canister:'.length - 'mo:'.length);
+
+// export function getCanisterPackageName(name: string) {
+//     return canisterPackagePrefix + name;
+// }
+
+export function preprocessMotoko(source: string): string {
+    // // Hack: replace canister import statements based on a regular expression.
+    // return source.replace(
+    //     /(import[^"\n]+")canister:([^"]+)(";?)/g,
+    //     (match, before, name, after) => {
+    //         if(dfxConfig.canisters.hasOwnProperty()){
+    //             return `${before}mo:${getCanisterPackageName(name)}${after}`;
+    //         }
+    //         return match
+    //     },
+    // );
+    return source;
+}


### PR DESCRIPTION
Adds compiler errors and warnings to Motoko files used by `dfx.json` canisters (and any dependencies of files opened in the editor). 