### PR TITLE
Use cached Motoko base library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
       "dev": true
     },
     "node_modules/motoko": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/motoko/-/motoko-2.0.10.tgz",
-      "integrity": "sha512-lWS5wK3FdEV/jdTD6B90duqIvHUHrgcJWMc2Y+uUFq4HWAezuViWwIYpesHY/osezeevBKA/iZ5Xn/galclgbw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/motoko/-/motoko-2.1.0.tgz",
+      "integrity": "sha512-ibgo8t3IjEvW3rZWFbCmgyWRfbGJVCzsqP85sfyoD7UcUSGLTm0v2/ikMtbdhHTYg4TIW5GlwOJFwH2mqczjTQ==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -2334,9 +2334,9 @@
       "dev": true
     },
     "motoko": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/motoko/-/motoko-2.0.10.tgz",
-      "integrity": "sha512-lWS5wK3FdEV/jdTD6B90duqIvHUHrgcJWMc2Y+uUFq4HWAezuViWwIYpesHY/osezeevBKA/iZ5Xn/galclgbw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/motoko/-/motoko-2.1.0.tgz",
+      "integrity": "sha512-ibgo8t3IjEvW3rZWFbCmgyWRfbGJVCzsqP85sfyoD7UcUSGLTm0v2/ikMtbdhHTYg4TIW5GlwOJFwH2mqczjTQ==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "rimraf ./out && tsc -p .",
+    "compile": "rimraf ./out && tsc -p . && npm run generate",
+    "generate": "node utils/downloadBaseLibrary.js",
     "lint": "tslint -p .",
     "package": "vsce package",
     "watch": "tsc -watch -p .",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -136,10 +136,17 @@ async function loadPackages() {
             }
         }
     } else {
-        const defaultPackages = {
-            base: 'dfinity/motoko-base/master/src',
-        };
-        await mo.loadPackages(defaultPackages);
+        // const defaultPackages = {
+        //     base: 'dfinity/motoko-base/master/src',
+        // };
+        // await mo.loadPackages(defaultPackages);
+
+        const basePackage = await import('../generated/base.json');
+        const baseDirectory = 'base_library';
+        Object.entries(basePackage.files).forEach(([path, file]) => {
+            mo.write(`${baseDirectory}/${path}`, file.content);
+        });
+        mo.addPackage('base', baseDirectory);
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "pretty": true,
     "strict": true,
+    "resolveJsonModule": true,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
     "strictFunctionTypes": true /* Enable strict checking of function types. */,

--- a/utils/downloadBaseLibrary.js
+++ b/utils/downloadBaseLibrary.js
@@ -4,13 +4,13 @@ const fs = require('fs');
 const mo = require('motoko');
 
 (async () => {
-    const package = await mo.fetchPackage('dfinity/motoko-base/master/src');
-    if (!package.name || !Object.entries(package.files).length) {
+    const basePackage = await mo.fetchPackage('dfinity/motoko-base/master/src');
+    if (!basePackage.name || !Object.entries(basePackage.files).length) {
         throw new Error('Unexpected package format');
     }
     fs.writeFileSync(
         __dirname + '/../src/generated/baseLibrary.json',
-        JSON.stringify(package),
+        JSON.stringify(basePackage),
     );
 })().catch((err) => {
     console.error(err);

--- a/utils/downloadBaseLibrary.js
+++ b/utils/downloadBaseLibrary.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const fs = require('fs');
+const mo = require('motoko');
+
+(async () => {
+    const package = await mo.fetchPackage('dfinity/motoko-base/master/src');
+    if (!package.name || !Object.entries(package.files).length) {
+        throw new Error('Unexpected package format');
+    }
+    fs.writeFileSync(
+        __dirname + '/../src/generated/baseLibrary.json',
+        JSON.stringify(package),
+    );
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
Switches to using a cached version of the Motoko base library rather than potentially calling the GitHub API on extension startup. 