### PR TITLE
Validate entire workspace on save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-motoko",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-motoko",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "fast-glob": "^3.2.11",
         "motoko": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-motoko",
   "displayName": "Motoko",
   "description": "Motoko language support",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "publisher": "dfinity-foundation",
   "repository": "https://github.com/dfinity/vscode-motoko",
   "engines": {


### PR DESCRIPTION
Validates the entire workspace on save (instead of only `dfx.json` canister entry points).