### PR TITLE
Syntax highlight `*.mo_` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         ],
         "extensions": [
           ".mo",
-          ".mox"
+          ".mo_"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
           "motoko"
         ],
         "extensions": [
-          ".mo"
+          ".mo",
+          ".mox"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -389,6 +389,11 @@ function notify(uri: string | TextDocument): boolean {
 function check(uri: string | TextDocument): boolean {
     // TODO: debounce
     try {
+        // Only check '*.mo' files
+        if (!(typeof uri === 'string' ? uri : uri?.uri).endsWith('.mo')) {
+            return false;
+        }
+
         let virtualPath: string;
         const document = typeof uri === 'string' ? documents.get(uri) : uri;
         if (document) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -389,8 +389,8 @@ function notify(uri: string | TextDocument): boolean {
 function check(uri: string | TextDocument): boolean {
     // TODO: debounce
     try {
-        // Only check '*.mo' files
-        if (!(typeof uri === 'string' ? uri : uri?.uri).endsWith('.mo')) {
+        const skipExtension = '.mo_';
+        if ((typeof uri === 'string' ? uri : uri?.uri).endsWith(skipExtension)) {
             return false;
         }
 
@@ -431,10 +431,12 @@ function check(uri: string | TextDocument): boolean {
         };
         diagnostics.forEach((diagnostic) => {
             const key = diagnostic.source || virtualPath;
-            (diagnosticMap[key] || (diagnosticMap[key] = [])).push({
-                ...diagnostic,
-                source: 'motoko',
-            });
+            if (!key.endsWith(skipExtension)) {
+                (diagnosticMap[key] || (diagnosticMap[key] = [])).push({
+                    ...diagnostic,
+                    source: 'motoko',
+                });
+            }
         });
 
         Object.entries(diagnosticMap).forEach(([path, diagnostics]) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -390,7 +390,12 @@ function check(uri: string | TextDocument): boolean {
     // TODO: debounce
     try {
         const skipExtension = '.mo_';
-        if ((typeof uri === 'string' ? uri : uri?.uri).endsWith(skipExtension)) {
+        const resolvedUri = typeof uri === 'string' ? uri : uri?.uri;
+        if (resolvedUri?.endsWith(skipExtension)) {
+            connection.sendDiagnostics({
+                uri: resolvedUri,
+                diagnostics: [],
+            });
             return false;
         }
 


### PR DESCRIPTION
This new underscored file extension makes it possible to use Motoko syntax highlighting without type checking, such as when creating templates or using a preprocessor.

Resolves #51.