### PR TITLE
Add basic web extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "onCommand:motoko.startService"
     ],
     "main": "./out/extension",
+    "browser": "./out/browser",
     "dependencies": {
         "fast-glob": "^3.2.11",
         "mnemonist": "^0.39.2",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,25 @@
+import { ExtensionContext } from 'vscode';
+// import { formatDocument } from './formatter';
+
+// const config = workspace.getConfiguration('motoko');
+
+export function activate(_context: ExtensionContext) {
+    // context.subscriptions.push(
+    //     commands.registerCommand('motoko.startService', () =>
+    //         startServer(context),
+    //     ),
+    // );
+    // context.subscriptions.push(
+    //     languages.registerDocumentFormattingEditProvider('motoko', {
+    //         provideDocumentFormattingEdits(
+    //             document: TextDocument,
+    //             options: FormattingOptions,
+    //         ): TextEdit[] {
+    //             return formatDocument(document, context, options);
+    //         },
+    //     }),
+    // );
+    // startServer(context);
+}
+
+export async function deactivate() {}


### PR DESCRIPTION
This PR is a first step toward supporting Motoko in browser-based environments such as [github.dev](https://github.dev/github/dev) and [vscode.dev](https://vscode.dev/). 