### PR TITLE
Clarify 'canister alias not defined' error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.5.1",
+            "version": "0.5.2",
             "dependencies": {
                 "change-case": "^4.1.2",
                 "fast-glob": "^3.2.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "dependencies": {
                 "change-case": "^4.1.2",
                 "fast-glob": "^3.2.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "vscode-motoko",
-    "version": "0.4.9",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.4.9",
+            "version": "0.5.0",
             "dependencies": {
                 "change-case": "^4.1.2",
                 "fast-glob": "^3.2.11",
                 "mnemonist": "^0.39.2",
                 "motoko": "^3.0.0",
                 "prettier": "^2.7.1",
-                "prettier-plugin-motoko": "^0.2.1",
+                "prettier-plugin-motoko": "^0.2.2",
                 "url-relative": "1.0.0",
                 "vscode-languageclient": "^8.0.2",
                 "vscode-languageserver": "^8.0.2",
@@ -5265,9 +5265,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.1.tgz",
-            "integrity": "sha512-tAwLukribu+Dlwdz57WeD7HeSZtSlZJF5TBf8GZP7p0q7wa4O4GlsiyhQR4xGi7XbeJXJgqP9bcPd5qyv1oqWA==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.2.tgz",
+            "integrity": "sha512-9nxyHMIY9ZyZq+2OYadHZ0YTEn3SIDm8Tkz0lgh5O1EBBQkQuGiRFtF3tgmaR4VV82CYFl7pp98MI40YRL3WBg==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -10452,9 +10452,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.1.tgz",
-            "integrity": "sha512-tAwLukribu+Dlwdz57WeD7HeSZtSlZJF5TBf8GZP7p0q7wa4O4GlsiyhQR4xGi7XbeJXJgqP9bcPd5qyv1oqWA==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.2.tgz",
+            "integrity": "sha512-9nxyHMIY9ZyZq+2OYadHZ0YTEn3SIDm8Tkz0lgh5O1EBBQkQuGiRFtF3tgmaR4VV82CYFl7pp98MI40YRL3WBg==",
             "requires": {}
         },
         "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
         "mnemonist": "^0.39.2",
         "motoko": "^3.0.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-motoko": "^0.2.1",
+        "prettier-plugin-motoko": "^0.2.2",
         "url-relative": "1.0.0",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2",


### PR DESCRIPTION
Encourages developers to try running `dfx deploy` if they run into the relatively common "canister alias not defined" error. 