### PR TITLE
viper: tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "rimraf": "^3.0.2",
                 "ts-jest": "^29.0.3",
                 "typescript": "^4.8.2",
-                "vsce": "^2.11.0"
+                "vsce": "^2.13.0"
             },
             "engines": {
                 "vscode": "^1.53.0"
@@ -6890,9 +6890,9 @@
             }
         },
         "node_modules/vsce": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.11.0.tgz",
-            "integrity": "sha512-pr9Y0va/HCer0tTifeqaUrK24JJSpRd6oLeF/PY6FtrY41e+lwxiAq6jfMXx4ShAZglYg2rFKoKROwa7E7SEqQ==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.13.0.tgz",
+            "integrity": "sha512-t1otQ2lqyi5Y/G6qUl9BEc561nEIYrZbLT8k+R1SoZaKNa6gaehaLGQG5zvB524YPGZOVvbOBzAXoO7Mor1J5g==",
             "dev": true,
             "dependencies": {
                 "azure-devops-node-api": "^11.0.1",
@@ -12321,9 +12321,9 @@
             }
         },
         "vsce": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.11.0.tgz",
-            "integrity": "sha512-pr9Y0va/HCer0tTifeqaUrK24JJSpRd6oLeF/PY6FtrY41e+lwxiAq6jfMXx4ShAZglYg2rFKoKROwa7E7SEqQ==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.13.0.tgz",
+            "integrity": "sha512-t1otQ2lqyi5Y/G6qUl9BEc561nEIYrZbLT8k+R1SoZaKNa6gaehaLGQG5zvB524YPGZOVvbOBzAXoO7Mor1J5g==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
         "rimraf": "^3.0.2",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.2",
-        "vsce": "^2.11.0"
+        "vsce": "^2.13.0"
     },
     "extensionDependencies": [
         "viper-admin.viper"
@@ -164,7 +164,7 @@
         "generate:viper": "cd ../motoko && nix-shell --command 'cd ../vscode-motoko/src/generated && cp -vf $VIPER_SERVER viperserver.jar && rm -f z3 && cp -v $(which z3) .'",
         "generate:moc": "cd ../motoko && nix-shell --command 'make -C src moc.js && cp -vfL src/moc.js ../vscode-motoko/src/generated/moc.js'",
         "generate": "mkdir -p src/generated && run-s generate:moc generate:viper",
-        "compile": "rimraf ./out && tsc -p . && cp -vr src/generated out/generated",
+        "compile": "rimraf ./out && tsc -p . && mkdir -p out/generated/ && ln -fv src/generated/* out/generated/",
         "test": "jest",
         "lint": "tslint -p .",
         "package": "vsce package",


### PR DESCRIPTION
Two minor changes
- fixed "The latest version of `vsce` is 2.13.0 and you have 2.11.0" warning
- save space by hard-linking contents of `src/generated` to `out/generated`.

The former looked like low-hanging fruit.
The latter is important for me, as my Mac has a 256 GB disk that is almost full :-)
```
[nix-shell:~/vscode-motoko]$ ls -l out/generated
total 124668
-r--r--r-- 2 ggreif staff 22063062 Oct 23 02:31 moc.js
-r--r--r-- 2 ggreif staff 81300825 Oct 23 02:31 viperserver.jar
-r-xr-xr-x 2 ggreif staff 24292476 Oct 23 02:31 z3
```

The `package-lock.json` changes were obtained by running `npm audit fix`.