### PR TITLE
Viper: shared language client connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,9 @@
         "typescript": "^4.8.2",
         "vsce": "^2.11.0"
     },
+    "extensionDependencies": [
+        "viper-admin.viper"
+    ],
     "scripts": {
         "vscode:prepublish": "run-s generate compile",
         "generate:viper": "cd ../motoko && nix-shell --command 'cd ../vscode-motoko/src/generated && cp -vf $VIPER_SERVER viperserver.jar && rm -f z3 && cp -v $(which z3) .'",

--- a/package.json
+++ b/package.json
@@ -156,9 +156,6 @@
         "typescript": "^4.8.2",
         "vsce": "^2.11.0"
     },
-    "extensionDependencies": [
-        "viper-admin.viper"
-    ],
     "scripts": {
         "vscode:prepublish": "run-s generate compile",
         "generate:viper": "cd ../motoko && nix-shell --command 'cd ../vscode-motoko/src/generated && cp -vf $VIPER_SERVER viperserver.jar && rm -f z3 && cp -v $(which z3) .'",

--- a/src/server/connection.ts
+++ b/src/server/connection.ts
@@ -1,0 +1,6 @@
+import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
+
+// Create a connection for the language server
+const connection = createConnection(ProposedFeatures.all);
+
+export default connection;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,26 +10,23 @@ import {
     CodeAction,
     CodeActionKind,
     CompletionItemKind,
-    CompletionList,
-    createConnection,
-    Diagnostic,
+    CompletionList, Diagnostic,
     DiagnosticSeverity,
     FileChangeType,
     InitializeResult,
     Location,
     MarkupKind,
-    Position,
-    ProposedFeatures,
-    SignatureHelp,
+    Position, SignatureHelp,
     TextDocumentPositionParams,
     TextDocuments,
     TextDocumentSyncKind,
     TextEdit,
-    WorkspaceFolder,
+    WorkspaceFolder
 } from 'vscode-languageserver/node';
 import { URI } from 'vscode-uri';
 import { watchGlob as virtualFilePattern } from '../common/watchConfig';
 import AstResolver from './ast';
+import connection from './connection';
 import DfxResolver from './dfx';
 import ImportResolver from './imports';
 import { getAstInformation } from './information';
@@ -39,7 +36,7 @@ import {
     formatMotoko,
     getFileText,
     resolveFilePath,
-    resolveVirtualPath,
+    resolveVirtualPath
 } from './utils';
 import { compileViper, invalidateViper } from './viper';
 
@@ -217,9 +214,6 @@ function notifyDfxChange() {
         checkWorkspace();
     }, 100);
 }
-
-// Create a connection for the language server
-const connection = createConnection(ProposedFeatures.all);
 
 const forwardMessage =
     (send: (message: string) => void) =>


### PR DESCRIPTION
I found a way to access the Viper extension's `LanguageClient`, making it possible to share the same LSP socket connection. However, this appears to cause problems in the Viper extension, which makes assumptions about state changes which are broken by our verification logic. 

Opening this PR for reference in case we want to revisit this approach at some point in the future. 
