### PR TITLE
Drop support for standalone 'mo-ide' binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Get this extension through the [VS Marketplace](https://marketplace.visualstudio
 
 - `motoko.dfx`: The location of the `dfx` binary
 - `motoko.canister`: The default canister name to use in multi-canister projects
-- `motoko.standaloneArguments`: Additional arguments to pass to the language service when running in a non-dfx project
-- `motoko.standaloneBinary`: The location of the `mo-ide` binary (when running in a non-dfx project)
 - `motoko.formatter`: The formatter used by the extension
 - `motoko.legacyDfxSupport`: Uses legacy `dfx`-dependent features when a `dfx.json` file is available
+- `motoko.standaloneArguments`: Additional arguments to pass to the language server when running in a non-dfx project
+- `motoko.standaloneBinary`: The location of a custom language server binary
 
 ## Recent Changes
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ Get this extension through the [VS Marketplace](https://marketplace.visualstudio
 - `motoko.dfx`: The location of the `dfx` binary
 - `motoko.canister`: The default canister name to use in multi-canister projects
 - `motoko.formatter`: The formatter used by the extension
-- `motoko.legacyDfxSupport`: Uses legacy `dfx`-dependent features when a `dfx.json` file is available
-- `motoko.standaloneArguments`: Additional arguments to pass to the language server when running in a non-dfx project
-- `motoko.standaloneBinary`: The location of a custom language server binary
+- `motoko.legacyDfxSupport`: Uses legacy `dfx`-dependent features when a relevant `dfx.json` file is available
 
 ## Recent Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "mnemonist": "^0.39.2",
                 "motoko": "^3.0.0",
                 "prettier": "^2.7.1",
-                "prettier-plugin-motoko": "^0.2.2",
+                "prettier-plugin-motoko": "^0.2.3",
                 "url-relative": "1.0.0",
                 "vscode-languageclient": "^8.0.2",
                 "vscode-languageserver": "^8.0.2",
@@ -4809,9 +4809,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5265,9 +5265,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.2.tgz",
-            "integrity": "sha512-9nxyHMIY9ZyZq+2OYadHZ0YTEn3SIDm8Tkz0lgh5O1EBBQkQuGiRFtF3tgmaR4VV82CYFl7pp98MI40YRL3WBg==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.3.tgz",
+            "integrity": "sha512-6n3ZWssbbCLVZfCjEwZcGmy+RvIP18HsPqMFo8G6ILoCYNyqzKwbuW7z9FxlwZSwia7e7vq301JgcoNEgS7afA==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -10099,9 +10099,9 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -10452,9 +10452,9 @@
             "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.2.tgz",
-            "integrity": "sha512-9nxyHMIY9ZyZq+2OYadHZ0YTEn3SIDm8Tkz0lgh5O1EBBQkQuGiRFtF3tgmaR4VV82CYFl7pp98MI40YRL3WBg==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.2.3.tgz",
+            "integrity": "sha512-6n3ZWssbbCLVZfCjEwZcGmy+RvIP18HsPqMFo8G6ILoCYNyqzKwbuW7z9FxlwZSwia7e7vq301JgcoNEgS7afA==",
             "requires": {}
         },
         "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
         "mnemonist": "^0.39.2",
         "motoko": "^3.0.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-motoko": "^0.2.2",
+        "prettier-plugin-motoko": "^0.2.3",
         "url-relative": "1.0.0",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -87,18 +87,6 @@
                     "default": "",
                     "description": "The name of the canister you want to develop. If this is blank, we'll use a sensible default."
                 },
-                "motoko.standaloneBinary": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "mo-ide",
-                    "description": "The location of a custom language server binary."
-                },
-                "motoko.standaloneArguments": {
-                    "scope": "resource",
-                    "type": "string",
-                    "default": "",
-                    "description": "Additional arguments to pass to the language server when running in a non-dfx project."
-                },
                 "motoko.formatter": {
                     "type": "string",
                     "default": "prettier",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
                     "scope": "resource",
                     "type": "string",
                     "default": "mo-ide",
-                    "description": "The path to the language server binary when running in a non-dfx project."
+                    "description": "The location of a custom language server binary."
                 },
                 "motoko.standaloneArguments": {
                     "scope": "resource",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,55 +45,47 @@ export function activate(context: ExtensionContext) {
 }
 
 export function startServer(context: ExtensionContext) {
+    // Custom `mo-ide` language server
+    // if (config.standaloneBinary && fs.existsSync(config.standaloneBinary)) {
+    //     const prompt = `There doesn't seem to be a dfx.json file for this Motoko project. What file do you want to use as an entry point?`;
+    //     const currentDocument = window.activeTextEditor?.document?.fileName;
+    //     window
+    //         .showInputBox({ prompt, value: currentDocument })
+    //         .then((entryPoint) => {
+    //             if (entryPoint) {
+    //                 const serverCommand = {
+    //                     command: config.standaloneBinary,
+    //                     args: ['--canister-main', entryPoint]
+    //                         .concat(vesselArgs())
+    //                         .concat(config.standaloneArguments.split(' ')),
+    //                 };
+    //                 launchClient(context, {
+    //                     run: serverCommand,
+    //                     debug: serverCommand,
+    //                 });
+    //             }
+    //         });
+    //     return;
+    // }
+
+    // Legacy dfx language server
     const dfxConfig = getDfxConfig();
     if (dfxConfig && getDfxPath()) {
         launchDfxProject(context, dfxConfig);
         return;
     }
 
-    // Check if `mo-ide` exists
-    fs.access(config.standaloneBinary, fs.constants.F_OK, (err) => {
-        try {
-            if (err) {
-                console.log(err.message);
-
-                // Launch cross-platform language server
-                const module = context.asAbsolutePath(
-                    path.join('out', 'server', 'server.js'),
-                );
-                launchClient(context, {
-                    run: { module, transport: TransportKind.ipc },
-                    debug: {
-                        module,
-                        options: { execArgv: ['--nolazy', '--inspect=6004'] },
-                        transport: TransportKind.ipc,
-                    },
-                });
-                return;
-            }
-
-            const prompt = `There doesn't seem to be a dfx.json file for this Motoko project. What file do you want to use as an entry point?`;
-            const currentDocument = window.activeTextEditor?.document?.fileName;
-
-            window
-                .showInputBox({ prompt, value: currentDocument })
-                .then((entryPoint) => {
-                    if (entryPoint) {
-                        const serverCommand = {
-                            command: config.standaloneBinary,
-                            args: ['--canister-main', entryPoint]
-                                .concat(vesselArgs())
-                                .concat(config.standaloneArguments.split(' ')),
-                        };
-                        launchClient(context, {
-                            run: serverCommand,
-                            debug: serverCommand,
-                        });
-                    }
-                });
-        } catch (err) {
-            console.error(err);
-        }
+    // Cross-platform language server
+    const module = context.asAbsolutePath(
+        path.join('out', 'server', 'server.js'),
+    );
+    launchClient(context, {
+        run: { module, transport: TransportKind.ipc },
+        debug: {
+            module,
+            options: { execArgv: ['--nolazy', '--inspect=6004'] },
+            transport: TransportKind.ipc,
+        },
     });
 }
 
@@ -206,20 +198,20 @@ function getDfxPath(): string {
     }
 }
 
-function vesselArgs(): string[] {
-    try {
-        let ws = workspace.workspaceFolders!![0].uri.fsPath;
-        if (
-            !fs.existsSync(path.join(ws, 'vessel.dhall')) &&
-            !fs.existsSync(path.join(ws, 'vessel.json'))
-        )
-            return [];
-        let flags = execSync('vessel sources', {
-            cwd: ws,
-        }).toString('utf8');
-        return flags.split(' ');
-    } catch (err) {
-        console.log(err);
-        return [];
-    }
-}
+// function vesselArgs(): string[] {
+//     try {
+//         let ws = workspace.workspaceFolders!![0].uri.fsPath;
+//         if (
+//             !fs.existsSync(path.join(ws, 'vessel.dhall')) &&
+//             !fs.existsSync(path.join(ws, 'vessel.json'))
+//         )
+//             return [];
+//         let flags = execSync('vessel sources', {
+//             cwd: ws,
+//         }).toString('utf8');
+//         return flags.split(' ');
+//     } catch (err) {
+//         console.log(err);
+//         return [];
+//     }
+// }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,29 +39,6 @@ export function activate(context: ExtensionContext) {
 }
 
 export function startServer(context: ExtensionContext) {
-    // Custom `mo-ide` language server
-    // if (config.standaloneBinary && fs.existsSync(config.standaloneBinary)) {
-    //     const prompt = `There doesn't seem to be a dfx.json file for this Motoko project. What file do you want to use as an entry point?`;
-    //     const currentDocument = window.activeTextEditor?.document?.fileName;
-    //     window
-    //         .showInputBox({ prompt, value: currentDocument })
-    //         .then((entryPoint) => {
-    //             if (entryPoint) {
-    //                 const serverCommand = {
-    //                     command: config.standaloneBinary,
-    //                     args: ['--canister-main', entryPoint]
-    //                         .concat(vesselArgs())
-    //                         .concat(config.standaloneArguments.split(' ')),
-    //                 };
-    //                 launchClient(context, {
-    //                     run: serverCommand,
-    //                     debug: serverCommand,
-    //                 });
-    //             }
-    //         });
-    //     return;
-    // }
-
     // Legacy dfx language server
     const dfxConfig = getDfxConfig();
     if (dfxConfig && getDfxPath()) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,25 +1,19 @@
-import {
-    workspace,
-    ExtensionContext,
-    window,
-    commands,
-    languages,
-    TextDocument,
-    TextEdit,
-    FormattingOptions,
-} from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as which from 'which';
-import { execSync } from 'child_process';
+import {
+    commands, ExtensionContext, FormattingOptions, languages,
+    TextDocument,
+    TextEdit, window, workspace
+} from 'vscode';
 import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
-    TransportKind,
+    TransportKind
 } from 'vscode-languageclient/node';
-import { formatDocument } from './formatter';
+import * as which from 'which';
 import { watchGlob } from './common/watchConfig';
+import { formatDocument } from './formatter';
 
 const config = workspace.getConfiguration('motoko');
 


### PR DESCRIPTION
Removes support for a configuring a global standalone language server, since this feature is no longer necessary and has the potential to cause confusion. 

This PR also updates `prettier-plugin-motoko` and applies changes from `npm audit fix`. 
