### PR TITLE
LSP: wait till port is up and parse it

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,9 +153,8 @@
     ],
     "scripts": {
         "vscode:prepublish": "run-s generate compile",
-        "generate:viper": "cd ../motoko && nix-shell --command 'cd ../vscode-motoko/src/generated && rm -f z3 && cp -v $(which z3) .'",
         "generate:moc": "cd ../motoko && nix-shell --command 'make -C src moc.js && cp -vfL src/moc.js ../vscode-motoko/src/generated/moc.js'",
-        "generate": "mkdir -p src/generated && run-s generate:moc generate:viper",
+        "generate": "mkdir -p src/generated && run-s generate:moc",
         "compile": "rimraf ./out && tsc -p . && mkdir -p out/generated/ && ln -fv src/generated/* out/generated/",
         "test": "jest",
         "lint": "tslint -p .",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     ],
     "scripts": {
         "vscode:prepublish": "run-s generate compile",
-        "generate:viper": "cd ../motoko && nix-shell --command 'cd ../vscode-motoko/src/generated && cp -vf $VIPER_SERVER viperserver.jar && rm -f z3 && cp -v $(which z3) .'",
+        "generate:viper": "cd ../motoko && nix-shell --command 'cd ../vscode-motoko/src/generated && rm -f z3 && cp -v $(which z3) .'",
         "generate:moc": "cd ../motoko && nix-shell --command 'make -C src moc.js && cp -vfL src/moc.js ../vscode-motoko/src/generated/moc.js'",
         "generate": "mkdir -p src/generated && run-s generate:moc generate:viper",
         "compile": "rimraf ./out && tsc -p . && mkdir -p out/generated/ && ln -fv src/generated/* out/generated/",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,7 +116,9 @@ export function startServer(context: ExtensionContext) {
     }
     if (config.viperServerSettings.serverJars) {
         serverJar = normalise(viperTools, config.viperServerSettings.serverJars);
-        // serverJar = normalise(config.viperServerSettings.serverJars['mac'][0]);
+        if(!serverJar.endsWith('.jar')) {
+            serverJar = path.join(serverJar, 'viperserver.jar');
+        }
     }
     if (config.paths.z3Executable) {
         z3 = normalise(viperTools, config.paths.z3Executable);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,7 @@ export function startServer(context: ExtensionContext) {
     if (config) {
         viperTools = normalise(viperTools, config.paths.viperToolsPath);
         const buildVersion = config.buildVersion || 'Stable';
+        // macOS (Viper extension bugfix)
         if (viperTools.endsWith('/Library/Application Support/Viper')) {
             // Rewrite default directory
             viperTools = path.resolve(
@@ -119,7 +120,16 @@ export function startServer(context: ExtensionContext) {
                 `Library/Application Support/Code/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`
             );
         }
-        else if(viperTools.endsWith('Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local/ViperTools')) {
+        // Linux (Viper extension bugfix)
+        else if (viperTools.endsWith('/.config/Viper')) {
+            // Rewrite default directory
+            viperTools = path.resolve(
+                homedir(),
+                `.vscode-server/data/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`
+            );
+        }
+        // Rewrite default LS path
+        if(viperTools.endsWith('/Local/ViperTools')) {
             // Replace 'Local' directory with current build version
             viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${buildVersion}/ViperTools`);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,7 @@ export function startServer(context: ExtensionContext) {
             );
         }
         // Rewrite default LS path
-        if(viperTools.endsWith('/Local/ViperTools')) {
+        if (viperTools.endsWith('/Local/ViperTools')) {
             // Replace 'Local' directory with current build version
             viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${buildVersion}/ViperTools`);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ export function startServer(context: ExtensionContext) {
             viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${buildVersion}/ViperTools`);
         }
 	// Codium tweak
-	if (process.argv[0].includes('/VSCodium.app/Contents/')) {
+	if (process.execPath.includes('/VSCodium.app/Contents/')) {
 	    viperTools = viperTools.replace(/\/Application Support\/Code\//, '/Application Support/VSCodium/');
 	}
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,13 +7,13 @@ import {
     languages,
     TextDocument,
     TextEdit,
-    workspace,
+    workspace
 } from 'vscode';
 import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
-    TransportKind,
+    TransportKind
 } from 'vscode-languageclient/node';
 import { watchGlob } from './common/watchConfig';
 import { formatDocument } from './formatter';
@@ -112,31 +112,25 @@ export function startServer(context: ExtensionContext) {
     if (config) {
         viperTools = normalise(viperTools, config.paths.viperToolsPath);
         const buildVersion = config.buildVersion || 'Stable';
-        // macOS (Viper extension bugfix)
-        if (viperTools.endsWith('/Library/Application Support/Viper')) {
+        const homePath = homedir();
+        // Viper extension v3.0.1
+        if (viperTools === path.resolve(homePath, 'Library/Application Support/Viper') ||
+            viperTools === path.resolve(homePath, '.config/Viper')) {
             // Rewrite default directory
             viperTools = path.resolve(
-                homedir(),
-                `Library/Application Support/Code/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`
-            );
-        }
-        // Linux (Viper extension bugfix)
-        else if (viperTools.endsWith('/.config/Viper')) {
-            // Rewrite default directory
-            viperTools = path.resolve(
-                homedir(),
-                `.vscode-server/data/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`
+                context.globalStorageUri.fsPath,
+                `../viper-admin.viper/${buildVersion}/ViperTools`
             );
         }
         // Rewrite default LS path
-        if (viperTools.endsWith('/Local/ViperTools')) {
+        else if (viperTools.endsWith('/Local/ViperTools')) {
             // Replace 'Local' directory with current build version
             viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${buildVersion}/ViperTools`);
         }
-	// Codium tweak
-	if (process.execPath.includes('/VSCodium.app/Contents/')) {
-	    viperTools = viperTools.replace(/\/Application Support\/Code\//, '/Application Support/VSCodium/');
-	}
+        // Codium tweak
+        if (process.execPath.includes('/VSCodium.app/Contents/')) {
+            viperTools = viperTools.replace(/\/Application Support\/Code\//, '/Application Support/VSCodium/');
+        }
     }
     if (config.javaSettings.javaBinary) {
         java = normalise(viperTools, config.javaSettings.javaBinary);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,9 +111,9 @@ export function startServer(context: ExtensionContext) {
     const config = workspace.getConfiguration('viperSettings');
     if (config) {
         viperTools = normalise(viperTools, config.paths.viperToolsPath);
+        const buildVersion = config.buildVersion || 'Stable';
         if (viperTools.endsWith('/Library/Application Support/Viper')) {
             // Rewrite default directory
-            const buildVersion = config.buildVersion || 'Stable';
             viperTools = path.resolve(
                 homedir(),
                 `Library/Application Support/Code/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,6 +110,7 @@ export function startServer(context: ExtensionContext) {
     const config = workspace.getConfiguration('viperSettings');
     if (config) {
         viperTools = normalise(viperTools, config.paths.viperToolsPath);
+        viperTools = viperTools.replace(/\/Local\//, config.buildVersion);
     }
     if (config.javaSettings.javaBinary) {
         java = normalise(viperTools, config.javaSettings.javaBinary);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,6 @@ interface PlatformDependentPath {
 
 const isLinux = /^linux/.test(process.platform);
 const isMac = /^darwin/.test(process.platform);
-const isWin = /^win/.test(process.platform);
 
 function first (paths: string | string[]) : string {
     if (typeof paths !== 'string') {
@@ -64,7 +63,6 @@ function normalise(path: string | PlatformDependentPath) : string {
         // handle object values
         if (isMac && path.mac) return normalise(first(path.mac))
         else if (isLinux && path.linux) return normalise(first(path.linux))
-        else if (isWin && path.windows) return normalise(first(path.windows))
         else throw new Error(`normalise() on an unsupported platform: ${process.platform}, or path missing`);
     } else {
         if (!path || path.length <= 2) return path;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,10 +41,23 @@ export function startServer(context: ExtensionContext) {
     const module = context.asAbsolutePath(
         path.join('out', 'server', 'server.js'),
     );
+
+    var java = '';
+    const config = workspace.getConfiguration('viperSettings');
+    if (config.javaSettings.javaBinary) {
+       java = config.javaSettings.javaBinary;
+    }
+    const args = ['--java="' + java + '"']
+
     launchClient(context, {
-        run: { module, transport: TransportKind.ipc },
+        run: {
+            module,
+            args,
+            transport: TransportKind.ipc
+	},
         debug: {
             module,
+            args,
             options: { execArgv: ['--nolazy', '--inspect=6004'] },
             transport: TransportKind.ipc,
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,11 +43,15 @@ export function startServer(context: ExtensionContext) {
     );
 
     var java = '';
+    var serverJars = '';
     const config = workspace.getConfiguration('viperSettings');
     if (config.javaSettings.javaBinary) {
        java = config.javaSettings.javaBinary;
     }
-    const args = ['--java="' + java + '"']
+    if (config.viperServerSettings.serverJars) {
+       serverJars = config.viperServerSettings.serverJars;
+    }
+    const args = [`--java="${java}"`, `--jars="${serverJars}"`]
 
     launchClient(context, {
         run: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,6 +133,10 @@ export function startServer(context: ExtensionContext) {
             // Replace 'Local' directory with current build version
             viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${buildVersion}/ViperTools`);
         }
+	// Codium tweak
+	if (process.argv[0].includes('/VSCodium.app/Contents/')) {
+	    viperTools = viperTools.replace(/\/Application Support\/Code\//, '/Application Support/VSCodium/');
+	}
     }
     if (config.javaSettings.javaBinary) {
         java = normalise(viperTools, config.javaSettings.javaBinary);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,10 +40,17 @@ export function activate(context: ExtensionContext) {
     startServer(context);
 }
 
+interface PlatformDependentPath {
+    windows?: string | string[];
+    mac?: string | string[];
+    linux?: string | string[];
+}
+
 // originally from https://github.com/viperproject/viper-ide/blob/master/client/src/Settings.ts
-function normalise(path: string) {
+function normalise(path: string | PlatformDependentPath) {
     if (typeof path !== 'string') {
-        throw new Error(`normalize() called with a non-string value: ${JSON.stringify(path)}`);
+        // TODO: handle object values
+        throw new Error(`normalise() called with a non-string value: ${JSON.stringify(path)}`);
     }
     if (!path || path.length <= 2) return path;
     while (path.includes('$')) {
@@ -56,7 +63,7 @@ function normalise(path: string) {
             index_of_dollar + 1,
             index_of_closing_slash,
         );
-        const envValue = process.env[envName];
+        const envValue: string = process.env[envName] || '';
         if (!envValue) {
             throw new Error(
                 `environment variable ${envName} used in path ${path} is not set`,
@@ -89,8 +96,8 @@ export function startServer(context: ExtensionContext) {
         java = normalise(config.javaSettings.javaBinary);
     }
     if (config.viperServerSettings.serverJars) {
-        // serverJar = normalise(config.viperServerSettings.serverJars);
-        serverJar = normalise(config.viperServerSettings.serverJars['mac'][0]); // TODO: choose depending on OS
+        serverJar = normalise(config.viperServerSettings.serverJars);
+        // serverJar = normalise(config.viperServerSettings.serverJars['mac'][0]);
     }
     if (config.paths.z3Executable) {
         z3 = normalise(config.paths.z3Executable);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ export function startServer(context: ExtensionContext) {
 
     var java = '';
     var serverJars = '';
+    var z3 = '';
     const config = workspace.getConfiguration('viperSettings');
     if (config.javaSettings.javaBinary) {
        java = normalise(config.javaSettings.javaBinary);
@@ -73,7 +74,10 @@ export function startServer(context: ExtensionContext) {
     if (config.viperServerSettings.serverJars) {
        serverJars = normalise(config.viperServerSettings.serverJars);
     }
-    const args = [`--java="${java}"`, `--jars="${serverJars}"`]
+    if (config.paths.z3Executable) {
+        z3 = normalise(config.paths.z3Executable);
+     }
+     const args = [`--java="${java}"`, `--jars="${serverJars}"`, `--z3="${z3}"`]
 
     launchClient(context, {
         run: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ export function startServer(context: ExtensionContext) {
         }
         else if(viperTools.endsWith('Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local/ViperTools')) {
             // Replace 'Local' directory with current build version
-            viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${config.buildVersion}/ViperTools`);
+            viperTools = viperTools.replace(/\/Local\/ViperTools$/, `/${buildVersion}/ViperTools`);
         }
     }
     if (config.javaSettings.javaBinary) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,7 @@ interface PlatformDependentPath {
 
 const isLinux = /^linux/.test(process.platform);
 const isMac = /^darwin/.test(process.platform);
+const isWin = /^win/.test(process.platform);
 
 function first (paths: string | string[]) : string {
     if (typeof paths !== 'string') {
@@ -63,6 +64,7 @@ function normalise(path: string | PlatformDependentPath) : string {
         // handle object values
         if (isMac && path.mac) return normalise(first(path.mac))
         else if (isLinux && path.linux) return normalise(first(path.linux))
+        else if (isWin && path.windows) return normalise(first(path.windows))
         else throw new Error(`normalise() on an unsupported platform: ${process.platform}, or path missing`);
     } else {
         if (!path || path.length <= 2) return path;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import { homedir } from 'os';
 import * as path from 'path';
 import {
     commands,
@@ -110,14 +111,24 @@ export function startServer(context: ExtensionContext) {
     const config = workspace.getConfiguration('viperSettings');
     if (config) {
         viperTools = normalise(viperTools, config.paths.viperToolsPath);
-        viperTools = viperTools.replace(/\/Local\//, config.buildVersion);
+        if (viperTools.endsWith('/Library/Application Support/Viper')) {
+            // Rewrite default directory
+            const buildVersion = config.buildVersion || 'Stable';
+            viperTools = path.resolve(
+                homedir(),
+                `Library/Application Support/Code/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`
+            );
+        }
+        else {
+            viperTools = viperTools.replace(/\/Local\//, config.buildVersion);
+        }
     }
     if (config.javaSettings.javaBinary) {
         java = normalise(viperTools, config.javaSettings.javaBinary);
     }
     if (config.viperServerSettings.serverJars) {
         serverJar = normalise(viperTools, config.viperServerSettings.serverJars);
-        if(!serverJar.endsWith('.jar')) {
+        if (!serverJar.endsWith('.jar')) {
             serverJar = path.join(serverJar, 'viperserver.jar');
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,8 +119,9 @@ export function startServer(context: ExtensionContext) {
                 `Library/Application Support/Code/User/globalStorage/viper-admin.viper/${buildVersion}/ViperTools`
             );
         }
-        else {
-            viperTools = viperTools.replace(/\/Local\//, config.buildVersion);
+        else if(viperTools.endsWith('Library/Application Support/Code/User/globalStorage/viper-admin.viper/Local/ViperTools')) {
+            // Replace 'Local' directory with current build version
+            viperTools = viperTools.replace(/\/Local\/ViperTools/, `/${config.buildVersion}/ViperTools`);
         }
     }
     if (config.javaSettings.javaBinary) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -611,7 +611,7 @@ function writeVirtual(path: string, content: string) {
     //     content = preprocessMotoko(content);
     // }
     mo.write(path, content);
-    invalidateViper(path);
+    // (this arrives after compileViper!) invalidateViper(path);
 }
 
 function deleteVirtual(path: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -54,7 +54,7 @@ interface MotokoSettings {
 }
 
 // Always ignore `node_modules/` (often used in frontend canisters)
-const ignoreGlobs = ['**/node_modules/**/*'];
+// const ignoreGlobs = ['**/node_modules/**/*'];
 const skipExtension = '.mo_';
 
 // const moFileSet = new Set();
@@ -386,26 +386,26 @@ let checkWorkspaceTimeout: ReturnType<typeof setTimeout>;
 function checkWorkspace() {
     clearTimeout(checkWorkspaceTimeout);
     checkWorkspaceTimeout = setTimeout(() => {
-        console.log('Checking workspace');
+        // console.log('Checking workspace');
 
-        workspaceFolders?.forEach((folder) => {
-            const folderPath = resolveFilePath(folder.uri);
-            glob.sync('**/*.mo', {
-                cwd: folderPath,
-                dot: false, // exclude directories such as `.vessel`
-                ignore: ignoreGlobs,
-            }).forEach((relativePath) => {
-                const path = join(folderPath, relativePath);
-                try {
-                    const file = URI.file(path).toString();
-                    // notify(file);
-                    check(file);
-                } catch (err) {
-                    console.error(`Error while checking Motoko file ${path}:`);
-                    console.error(err);
-                }
-            });
-        });
+        // workspaceFolders?.forEach((folder) => {
+        //     const folderPath = resolveFilePath(folder.uri);
+        //     glob.sync('**/*.mo', {
+        //         cwd: folderPath,
+        //         dot: false, // exclude directories such as `.vessel`
+        //         ignore: ignoreGlobs,
+        //     }).forEach((relativePath) => {
+        //         const path = join(folderPath, relativePath);
+        //         try {
+        //             const file = URI.file(path).toString();
+        //             // notify(file);
+        //             check(file);
+        //         } catch (err) {
+        //             console.error(`Error while checking Motoko file ${path}:`);
+        //             console.error(err);
+        //         }
+        //     });
+        // });
 
         // validateOpenDocuments();
 

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -9,11 +9,8 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
 import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { sendDiagnostics } from './server';
 
-//const args = process.argv.slice(2);
-const args = process.argv;
-//console.error("args: ", args);
 var java = 'java';
-args.forEach((val) => {
+process.argv.forEach((val) => {
     const m = val.match(/--java="(.+)"/);
     if (m) { java = m[1] }
 });

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -255,7 +255,7 @@ export function compileViper(motokoUri: string): Diagnostic[] {
                                     uri: viperUri,
                                     backend: 'silicon',
                                     customArgs: [
-                                        '--logLevel WARN',
+                                        '--logLevel ERROR',
                                         `"${resolveFilePath(viperUri)}"`,
                                     ].join(' '),
                                     manuallyTriggered: true,

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -8,9 +8,9 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
 import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { sendDiagnostics } from './server';
 
-var java = 'java';
-var jars = '';
-var z3 = '';
+let java = 'java';
+let jars = '';
+let z3 = '';
 
 process.argv.forEach((val) => {
     const m = val.match(/--java="(.+)"/);

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -2,7 +2,7 @@
 import mo from './motoko';
 import { spawn } from 'child_process';
 import * as rpc from 'vscode-jsonrpc/node';
-import { resolve } from 'path';
+//import { resolve } from 'path';
 import { connect } from 'net';
 import { resolveFilePath, resolveVirtualPath } from './utils';
 import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
@@ -11,17 +11,22 @@ import { sendDiagnostics } from './server';
 
 var java = 'java';
 var jars = '';
+var z3 = '';
+
 process.argv.forEach((val) => {
     const m = val.match(/--java="(.+)"/);
     if (m) { java = m[1] }
     const n = val.match(/--jars="(.+)"/);
     if (n) { jars = n[1] }
+    const z = val.match(/--z3="(.+)"/);
+    if (z) { z3 = z[1] }
 });
 console.log("java: ", java);
 console.log("jars: ", jars);
+console.log("z3: ", z3);
 
 //const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
-const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
+//const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
 const verificationDebounce = 500; // TODO: config
 
 // Viper LSP server connection
@@ -41,7 +46,7 @@ try {
         ],
         {
             env: {
-                Z3_EXE: z3Path,
+                Z3_EXE: z3,
             },
         },
     ).on('error', console.error);

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -51,7 +51,7 @@ try {
             );
             connection.listen();
 
-            console.log('Listening to Viper LSP (port: %s)', port);
+            console.log(`Listening to Viper LSP (port: ${port})`);
 
             connection.sendNotification(new rpc.NotificationType('initialize'), {
                 processId: null,

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -10,11 +10,15 @@ import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { sendDiagnostics } from './server';
 
 var java = 'java';
+var jars = '';
 process.argv.forEach((val) => {
     const m = val.match(/--java="(.+)"/);
     if (m) { java = m[1] }
+    const n = val.match(/--jars="(.+)"/);
+    if (n) { jars = n[1] }
 });
 console.log("java: ", java);
+console.log("jars: ", jars);
 
 const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
 const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -2,7 +2,6 @@
 import mo from './motoko';
 import { spawn } from 'child_process';
 import * as rpc from 'vscode-jsonrpc/node';
-//import { resolve } from 'path';
 import { connect } from 'net';
 import { resolveFilePath, resolveVirtualPath } from './utils';
 import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
@@ -25,8 +24,6 @@ console.log("java: ", java);
 console.log("jars: ", jars);
 console.log("z3: ", z3);
 
-//const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
-//const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
 const verificationDebounce = 500; // TODO: config
 
 // Viper LSP server connection

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -35,8 +35,7 @@ try {
         },
     ).on('error', console.error);
 
-    server.stdout.on('data', (data: Buffer) => {
-        if (connection) return;
+    server.stdout.once('data', (data: Buffer) => {
         const s = data.toString()
         console.log(s);
         const m = s.match(/<ViperServerPort:([0-9]+)>/);

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -18,7 +18,7 @@ let connection: rpc.MessageConnection | undefined;
 
 try {
     const server = spawn(
-        '/nix/store/p4qnsh2pfcw444z0p0jji6rf0hl5r9wk-zulu17.34.19-ca-jdk-17.0.3/bin/java',
+        'java',
         [
             '-Xmx2048m',
             '-Xss16m',
@@ -35,9 +35,9 @@ try {
         },
     ).on('error', console.error);
 
-    server.stdout.on('data', (data) => {
-        if (connection != undefined) return;
-        const s = (data as Buffer).toString()
+    server.stdout.on('data', (data: Buffer) => {
+        if (connection) return;
+        const s = data.toString()
         console.log(s);
         const m = s.match(/<ViperServerPort:([0-9]+)>/);
         if (!m) {

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -9,7 +9,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
 import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { sendDiagnostics } from './server';
 
-//const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
+const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
 const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
 const verificationDebounce = 500; // TODO: config
 
@@ -23,10 +23,10 @@ try {
             '-Xmx2048m',
             '-Xss16m',
             '-jar',
-            '/nix/store/v202v4jgrc39hjpi7b7613b7qkv5z4lm-viperserver.jar',
+            viperServerPath,
+            '--singleClient',
             '--serverMode',
             'LSP',
-            '--singleClient',
         ],
         {
             env: {
@@ -58,7 +58,6 @@ try {
             });
 
             connection.onRequest(new rpc.RequestType('GetViperFileEndings'), () => {
-                console.log('Viper LSP: GetViperFileEndings');
                 return {
                     fileEndings: ['*.mo.vpr'],
                 };

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -39,7 +39,7 @@ try {
         if (connection != undefined) return;
         const s = (data as Buffer).toString()
         console.log(s);
-        const m = s.match(/:([0-9]+)>/);
+        const m = s.match(/<ViperServerPort:([0-9]+)>/);
         if (!m) {
             return
         } else {

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -50,7 +50,7 @@ try {
 
     const dataListener = (data: Buffer) => {
         const s = data.toString()
-        console.log(s);
+        console.log(`[Viper LS] ${s}`);
         const m = s.match(/<ViperServerPort:([0-9]+)>/);
         if (!m) {
             return

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -11,7 +11,13 @@ import { sendDiagnostics } from './server';
 
 //const args = process.argv.slice(2);
 const args = process.argv;
-console.error("args: ", args);
+//console.error("args: ", args);
+var java = 'java';
+args.forEach((val) => {
+    const m = val.match(/--java="(.+)"/);
+    if (m) { java = m[1] }
+});
+console.log("java: ", java);
 
 const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
 const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
@@ -22,7 +28,7 @@ let connection: rpc.MessageConnection | undefined;
 
 try {
     const server = spawn(
-        'java',
+        java,
         [
             '-Xmx2048m',
             '-Xss16m',

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -35,13 +35,14 @@ try {
         },
     ).on('error', console.error);
 
-    server.stdout.once('data', (data: Buffer) => {
+    const dataListener = (data: Buffer) => {
         const s = data.toString()
         console.log(s);
         const m = s.match(/<ViperServerPort:([0-9]+)>/);
         if (!m) {
             return
         } else {
+            server.stdout.off('data', dataListener); // Unsubscribe listener
             const port = Number(m[1]);
             const socket = connect(port);
             connection = rpc.createMessageConnection(
@@ -150,7 +151,8 @@ try {
                 },
             );
         }
-    });
+    };
+    server.stdout.on('data', dataListener);
 } catch (err) {
     console.error(`Error while initializing Viper LSP: ${err}`);
 }

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -9,19 +9,19 @@ import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { sendDiagnostics } from './server';
 
 let java = 'java';
-let jars = '';
+let jar = '';
 let z3 = '';
 
 process.argv.forEach((val) => {
     const m = val.match(/--java="(.+)"/);
     if (m) { java = m[1] }
-    const n = val.match(/--jars="(.+)"/);
-    if (n) { jars = n[1] }
+    const n = val.match(/--jar="(.+)"/);
+    if (n) { jar = n[1] }
     const z = val.match(/--z3="(.+)"/);
     if (z) { z3 = z[1] }
 });
 console.log("java: ", java);
-console.log("jars: ", jars);
+console.log("jar: ", jar);
 console.log("z3: ", z3);
 
 const verificationDebounce = 500; // TODO: config
@@ -36,7 +36,7 @@ try {
             '-Xmx2048m',
             '-Xss16m',
             '-jar',
-            jars,
+            jar,
             '--singleClient',
             '--serverMode',
             'LSP',

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -144,49 +144,12 @@ try {
                 },
             );
 
-            // connection.onNotification(
-            //     new rpc.NotificationType<{
-            //         uri: string;
-            //         diagnostics: Diagnostic[];
-            //     }>('textDocument/publishDiagnostics'),
-            //     ({ uri, diagnostics }) => {
-            //         console.log('Diagnostics:', uri, diagnostics);
-            //     },
-            // );
-
-            connection.onNotification(
-                new rpc.NotificationType<{ uri: string }>('VerificationNotStarted'),
-                () => {
-                    console.log('(Verification not started)');
-                },
-            );
-
             connection.onNotification(
                 new rpc.NotificationType<{ data: string; logLevel: number }>('Log'),
                 ({ data }) => {
                     console.log(data);
                 },
             );
-
-            const showMessageTypes = [
-                'warnings_during_parsing',
-                'ast_construction_result',
-            ];
-            connection.onNotification(
-                new rpc.NotificationType<{
-                    msgType: string;
-                    msg: string;
-                    logLevel: number;
-                }>('UnhandledViperServerMessageType'),
-                ({ msgType, msg }) => {
-                    if (showMessageTypes.includes(msgType)) {
-                        console.log(msg);
-                    }
-                    // else {
-                    //     console.log(`[${msgType}]`);
-                    // }
-                },
-            )
         }
     });
 } catch (err) {

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -20,7 +20,7 @@ process.argv.forEach((val) => {
 console.log("java: ", java);
 console.log("jars: ", jars);
 
-const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
+//const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
 const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
 const verificationDebounce = 500; // TODO: config
 
@@ -34,7 +34,7 @@ try {
             '-Xmx2048m',
             '-Xss16m',
             '-jar',
-            viperServerPath,
+            jars,
             '--singleClient',
             '--serverMode',
             'LSP',

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -9,6 +9,10 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
 import { existsSync, unlinkSync, writeFileSync } from 'fs';
 import { sendDiagnostics } from './server';
 
+//const args = process.argv.slice(2);
+const args = process.argv;
+console.error("args: ", args);
+
 const viperServerPath = resolve(__dirname, '../generated/viperserver.jar'); // TODO: detect from Viper extension
 const z3Path = resolve(__dirname, '../generated/z3'); // TODO: detect from Viper extension
 const verificationDebounce = 500; // TODO: config


### PR DESCRIPTION
This captures the LSP's output and waits until it announces its listening port. Then the connection is set up towards that port.

- Avoids premature connect when the listening port is not ready yet. (This happened routinely on my Mac.)
- Also avoids the fixing of a port number for LSP.
- Also eliminates Viper-related junk from the distribution (reducing size) and reuses the artefacts that come with Viper itself.

_CAVEAT_: You'll need to install the "pre-release" Viper extension from the marketplace and (suggested) switch the tool download to `Nightly`.

Open issue:
- locate the `java` binary (there is an npm for that!)