### PR TITLE
Fix formatter for bundled extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.5.6",
+            "version": "0.5.7",
             "dependencies": {
                 "change-case": "^4.1.2",
                 "fast-glob": "^3.2.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -151,10 +151,10 @@
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "npm run compile:pre && run-p compile:main compile:browser compile:server",
-        "compile:pre": "rimraf ./out && mkdirp ./out/server && cp node_modules/prettier-plugin-motoko/wasm/pkg/nodejs/wasm_bg.wasm out/server/wasm_bg.wasm",
+        "compile:pre": "rimraf ./out && mkdirp ./out && cp node_modules/prettier-plugin-motoko/wasm/pkg/nodejs/wasm_bg.wasm out/wasm_bg.wasm",
         "compile:main": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
         "compile:browser": "esbuild ./src/browser.ts --bundle --outfile=out/browser.js --external:vscode --format=cjs --platform=node --minify",
-        "compile:server": "esbuild ./src/server/server.ts --bundle --outfile=out/server/server.js --external:vscode --format=cjs --platform=node --minify",
+        "compile:server": "esbuild ./src/server/server.ts --bundle --outfile=out/server.js --external:vscode --format=cjs --platform=node --minify",
         "test": "jest",
         "package": "vsce package",
         "format": "prettier --write .",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export function startServer(context: ExtensionContext) {
 
     // Cross-platform language server
     const module = context.asAbsolutePath(
-        path.join('out', 'server', 'server.js'),
+        path.join('out', 'server.js'),
     );
     launchClient(context, {
         run: { module, transport: TransportKind.ipc },

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -9,6 +9,7 @@ import {
 } from 'vscode';
 import { join } from 'path';
 import { getCurrentWorkspaceRootFsPath } from './utils';
+import * as motokoPlugin from 'prettier-plugin-motoko';
 
 export function formatDocument(
     document: TextDocument,
@@ -31,11 +32,6 @@ export function formatDocument(
             if (!fileInfo.ignored) {
                 const source = document.getText();
 
-                const pluginPath = join(
-                    context.extensionPath,
-                    'node_modules',
-                    'prettier-plugin-motoko',
-                );
                 const config = prettier.resolveConfig.sync(
                     document.uri.fsPath /* , options */,
                 );
@@ -46,7 +42,7 @@ export function formatDocument(
                     filepath: document.fileName,
                     // parser: "motoko-tt-parse",
                     pluginSearchDirs: [context.extensionPath],
-                    plugins: [pluginPath],
+                    plugins: [motokoPlugin],
                     tabWidth: options.tabSize,
                     useTabs: !options.insertSpaces,
                     ...(config || {}),


### PR DESCRIPTION
Fixes a regression from #99 involving the position of the `prettier-plugin-motoko` Wasm file in the bundled output directory.