### PR TITLE
Go-to-definition support, first pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",
                 "mnemonist": "0.39.5",
-                "motoko": "3.1.1",
+                "motoko": "3.2.1",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.2.6",
                 "url-relative": "1.0.0",
@@ -7100,9 +7100,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.1.1.tgz",
-            "integrity": "sha512-Gd6KGta2ErBw/sMpkKqZPJEKOrsIM3I31mwW3rLSFIXxDNjvumCmdACgXVl4pL9Mp3SHlOjw1Ut/uUFHbXe2dw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.2.1.tgz",
+            "integrity": "sha512-Q7Z2re03OrnA0nbDVXZ1pr0L4FTtKpuMDmdGPUJKxG/6Agv4WZoMI2Vso948dFklqBcfNuaXIA08sfZGFKAazQ==",
             "dependencies": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
@@ -14455,9 +14455,9 @@
             }
         },
         "motoko": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.1.1.tgz",
-            "integrity": "sha512-Gd6KGta2ErBw/sMpkKqZPJEKOrsIM3I31mwW3rLSFIXxDNjvumCmdACgXVl4pL9Mp3SHlOjw1Ut/uUFHbXe2dw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.2.1.tgz",
+            "integrity": "sha512-Q7Z2re03OrnA0nbDVXZ1pr0L4FTtKpuMDmdGPUJKxG/6Agv4WZoMI2Vso948dFklqBcfNuaXIA08sfZGFKAazQ==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "change-case": "4.1.2",
         "fast-glob": "3.2.12",
         "mnemonist": "0.39.5",
-        "motoko": "3.1.1",
+        "motoko": "3.2.1",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.2.6",
         "url-relative": "1.0.0",

--- a/src/server/ast.ts
+++ b/src/server/ast.ts
@@ -1,7 +1,7 @@
 import { AST } from 'motoko/lib/ast';
-import { resolveVirtualPath, tryGetFileText } from './utils';
-import { fromAST, Program } from './syntax';
 import { getContext } from './context';
+import { Program, fromAST } from './syntax';
+import { resolveVirtualPath, tryGetFileText } from './utils';
 
 export interface AstStatus {
     uri: string;

--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -161,7 +161,6 @@ export function findDefinition(
     if (importDefinition) {
         return locationFromDefinition(importDefinition);
     }
-    // console.log('NODE:', node); ////
     const path = getSearchPath(node);
     if (!path.length) {
         console.log('Reference not found from AST node:', node.name);
@@ -264,11 +263,10 @@ function followImport(
         const uri = context.importResolver.getFileSystemURI(
             path.includes(':')
                 ? path
-                : // : getAbsoluteUri(reference.uri, '..', `${path}.mo`); // TODO: `lib.mo`
-                  getAbsoluteUri(reference.uri, '..', path),
+                : getAbsoluteUri(reference.uri, '..', path),
         );
         if (!uri) {
-            console.log('Unknown file system URI:', uri);
+            console.log('Unknown file system URI for path:', path);
             return;
         }
         const status = context.astResolver.request(uri);

--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -1,0 +1,167 @@
+import { AST, Node, Span } from 'motoko/lib/ast';
+import { findNodes, matchNode } from './syntax';
+import { Position, Range } from 'vscode-languageserver';
+
+export interface Source {
+    uri: string;
+    node: Node;
+}
+
+export class Definition {
+    readonly name: string;
+    readonly source: Source;
+
+    constructor(name: string, source: Source) {
+        this.name = name;
+        this.source = source;
+    }
+}
+
+export class Reference {
+    readonly name: string;
+    readonly source: Source;
+    readonly definition: Definition;
+
+    constructor(name: string, source: Source, definition: Definition) {
+        this.name = name;
+        this.source = source;
+        this.definition = definition;
+    }
+}
+
+export function findMostSpecificNodeForPosition(
+    ast: AST,
+    position: Position,
+    scoreFn: (node: Node) => number | boolean,
+    includeEndCharacter = false,
+): (Node & { start: Span; end: Span }) | undefined {
+    const nodes = findNodes(
+        ast,
+        (node) =>
+            !node.file &&
+            node.start &&
+            node.end &&
+            position.line >= node.start[0] - 1 &&
+            position.line <= node.end[0] - 1 &&
+            // position.line == node.start[0] - 1 &&
+            (position.line !== node.start[0] - 1 ||
+                position.character >= node.start[1]) &&
+            (position.line !== node.end[0] - 1 ||
+                position.character <
+                    node.end[1] + (includeEndCharacter ? 0 : 1)),
+    );
+
+    // Find the most specific AST node for the cursor position
+    let node: Node | undefined;
+    let nodeLines: number;
+    let nodeChars: number;
+    nodes.forEach((n: Node) => {
+        // if (ignoredAstNodes.includes(n.name)) {
+        //     return;
+        // }
+        const nLines = n.end![0] - n.start![0];
+        const nChars = n.end![1] - n.start![1];
+        if (
+            !node ||
+            scoreFn(n) > scoreFn(node) ||
+            nLines < nodeLines ||
+            (nLines == nodeLines && nChars < nodeChars)
+        ) {
+            node = n;
+            nodeLines = nLines;
+            nodeChars = nChars;
+        }
+    });
+    return node as (Node & { start: Span; end: Span }) | undefined;
+}
+
+export function rangeFromNode(
+    node: Node | undefined,
+    multiLineFromBeginning = false,
+): Range | undefined {
+    if (!node || !node.start || !node.end) {
+        return;
+    }
+    // const isSameLine = node.start[0] === node.end[0];
+    return {
+        start: {
+            line: node.start[0] - 1,
+            character:
+                multiLineFromBeginning && node.start[0] !== node.end[0]
+                    ? 0
+                    : node.start[1],
+            // character: node.start[1],
+        },
+        end: {
+            line: node.end[0] - 1,
+            character: node.end[1],
+        },
+    };
+}
+
+function findInPattern(expected: string, pat: Node): Node | undefined {
+    console.log('FIND:', expected, pat); /////////
+    return (
+        matchNode(pat, 'ObjP', (...args) => {
+            return args.map((field: Node & { args: [Node] }) => {
+                const name = field.name;
+                const alias = matchNode(
+                    field.args[0],
+                    'VarP',
+                    (alias) => alias,
+                    name,
+                );
+                if (alias === expected) {
+                    return field.args[0];
+                }
+                if (!alias && name === expected) {
+                    return field;
+                }
+                return;
+            });
+        }) ||
+        matchNode(pat, 'VarP', (name) => {
+            console.log('VAR:', name, name === expected); ///////
+            if (name === expected) {
+                return pat;
+            }
+            return;
+        })
+    );
+}
+
+export function findDefinition(
+    expected: string,
+    source: Source,
+): Source | undefined {
+    console.log('Expected:', expected); ////
+
+    let node = source.node.parent;
+    console.log('PARENT:::', source.node.parent); ///////
+    while (node) {
+        if (node.args) {
+            for (const arg of node.args) {
+                console.log('ARG:', arg); /////
+                const declaration = matchNode(arg, 'LetD', (pat) => {
+                    // matchNode(exp, 'ImportE', (path) => {
+                    //     const import_ = new Import(exp, path);
+                    //     // Variable pattern name
+                    //     import_.name = matchNode(pat, 'VarP', (name) => name);
+                    //     // Object pattern fields
+                    //     import_.fields =
+                    //     prog.imports.push(import_);
+                    // });
+                    return findInPattern(expected, pat);
+                });
+                if (declaration) {
+                    return {
+                        uri: source.uri,
+                        node: declaration,
+                    };
+                }
+            }
+        }
+        node = node.parent;
+    }
+    return;
+}

--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -137,6 +137,12 @@ interface Reference {
     source: Source;
 }
 
+const nodePriorities: Record<string, number> = {
+    // ImportE: 2,
+    VarE: 1,
+    PathT: 1,
+};
+
 export function findDefinition(
     uri: string,
     position: Position,
@@ -152,7 +158,7 @@ export function findDefinition(
     const node = findMostSpecificNodeForPosition(
         status.ast,
         position,
-        (node) => node.name === 'VarE' || node.name === 'PathT',
+        (node) => nodePriorities[node.name] || 0,
     );
     if (!node) {
         return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -384,7 +384,7 @@ connection.onInitialize((event): InitializeResult => {
                 triggerCharacters: ['.'],
             },
             definitionProvider: true,
-            declarationProvider: true,
+            // declarationProvider: true,
             // referencesProvider: true,
             codeActionProvider: true,
             hoverProvider: true,
@@ -1030,18 +1030,25 @@ connection.onDefinition(
         event: TextDocumentPositionParams,
     ): Promise<Location | Location[]> => {
         console.log('[Definition]');
-        return findDefinition(event.textDocument.uri, event.position) || [];
+        try {
+            return findDefinition(event.textDocument.uri, event.position) || [];
+        } catch (err) {
+            console.error(`Error while finding definition:`);
+            console.error(err);
+            // throw err;
+            return [];
+        }
     },
 );
 
-connection.onDeclaration(
-    async (
-        event: TextDocumentPositionParams,
-    ): Promise<Location | Location[]> => {
-        console.log('[Declaration]');
-        return findDefinition(event.textDocument.uri, event.position) || [];
-    },
-);
+// connection.onDeclaration(
+//     async (
+//         event: TextDocumentPositionParams,
+//     ): Promise<Location | Location[]> => {
+//         console.log('[Declaration]');
+//         return findDefinition(event.textDocument.uri, event.position) || [];
+//     },
+// );
 
 connection.onReferences(
     async (_event: ReferenceParams): Promise<Location[]> => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1030,7 +1030,7 @@ connection.onDefinition(
         event: TextDocumentPositionParams,
     ): Promise<Location | Location[]> => {
         console.log('[Definition]');
-        return (await onDefinition(event)) || [];
+        return findDefinition(event.textDocument.uri, event.position) || [];
     },
 );
 
@@ -1039,36 +1039,9 @@ connection.onDeclaration(
         event: TextDocumentPositionParams,
     ): Promise<Location | Location[]> => {
         console.log('[Declaration]');
-        return (await onDefinition(event)) || [];
+        return findDefinition(event.textDocument.uri, event.position) || [];
     },
 );
-
-async function onDefinition(
-    event: TextDocumentPositionParams,
-): Promise<Location | undefined> {
-    const { uri } = event.textDocument;
-    const context = getContext(uri);
-    const status = context.astResolver.request(uri);
-    if (!status?.ast || status.outdated) {
-        console.warn('Missing AST for', uri);
-        return;
-    }
-    console.log(status.ast); ///
-    const node = findMostSpecificNodeForPosition(
-        status.ast,
-        event.position,
-        (node) => node.name === 'VarE',
-    );
-    if (!node) {
-        return;
-    }
-    const def = findDefinition(node.args![0] as string, { uri, node });
-    console.log('DEF:', def); /////
-    if (!def) {
-        return;
-    }
-    return Location.create(def.uri, rangeFromNode(def.node)!);
-}
 
 connection.onReferences(
     async (_event: ReferenceParams): Promise<Location[]> => {

--- a/src/server/syntax.ts
+++ b/src/server/syntax.ts
@@ -88,8 +88,14 @@ export function fromAST(ast: AST): Syntax {
     }
 }
 
+export function asNode(ast: AST | undefined): Node | undefined {
+    return ast && typeof ast === 'object' && !Array.isArray(ast)
+        ? ast
+        : undefined;
+}
+
 export function matchNode<T>(
-    ast: AST,
+    ast: AST | undefined,
     name: string,
     fn: (...args: any) => T,
     defaultValue?: T,

--- a/src/server/syntax.ts
+++ b/src/server/syntax.ts
@@ -95,7 +95,7 @@ export function matchNode<T>(
     defaultValue?: T,
 ): T | undefined {
     if (
-        !!ast &&
+        ast &&
         typeof ast === 'object' &&
         !Array.isArray(ast) &&
         ast.name === name

--- a/src/server/utils.spec.ts
+++ b/src/server/utils.spec.ts
@@ -14,6 +14,6 @@ describe('utils', () => {
         // expect(getAbsoluteUri('file://a/b', '..')).toStrictEqual('file://a');
         expect(getAbsoluteUri('file:///a/b', '..')).toStrictEqual('file:///a');
         expect(getAbsoluteUri('mo:a/b', '../c')).toStrictEqual('mo:a/c');
-        expect(getAbsoluteUri('file:///a', 'mo:b')).toStrictEqual('mo:b');
+        // expect(getAbsoluteUri('file:///a', 'mo:b')).toStrictEqual('mo:b');
     });
 });

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { URI, Utils } from 'vscode-uri';
-import * as prettier from 'prettier/standalone';
 import * as motokoPlugin from 'prettier-plugin-motoko';
+import * as prettier from 'prettier/standalone';
+import { URI, Utils } from 'vscode-uri';
 
 /**
  * Resolves the absolute file system path from the given URI.

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -62,9 +62,9 @@ export function getRelativeUri(from: string, to: string): string {
     return require('url-relative')(from, to);
 }
 
-export function getAbsoluteUri(base: string, path: string): string {
-    if (/^[a-z]+:/i.test(path)) {
-        return path;
-    }
-    return Utils.joinPath(URI.parse(base), path).toString();
+export function getAbsoluteUri(base: string, ...paths: string[]): string {
+    // if (/^[a-z]+:/i.test(path)) {
+    //     return path;
+    // }
+    return Utils.joinPath(URI.parse(base), ...paths).toString();
 }


### PR DESCRIPTION
Implements ["Go to definition"](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition) functionality for local variables, type aliases, record literals, modules, and imports (including from Vessel / MOPS packages). 

This is a work-in-progress feature with lots of corner cases. Bug reports are welcome!
