### PR TITLE
Add `mo:` URI handler for base library navigation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,15 @@
 import * as fs from 'fs';
+import { Package } from 'motoko/lib/package';
+import * as baseLibrary from 'motoko/packages/latest/base.json';
 import * as path from 'path';
 import {
-    commands,
     ExtensionContext,
     FormattingOptions,
-    languages,
     TextDocument,
     TextEdit,
+    Uri,
+    commands,
+    languages,
     window,
     workspace,
 } from 'vscode';
@@ -37,6 +40,19 @@ export function activate(context: ExtensionContext) {
                 options: FormattingOptions,
             ): TextEdit[] {
                 return formatDocument(document, context, options);
+            },
+        }),
+    );
+    // Virtual base library URIs
+    context.subscriptions.push(
+        workspace.registerTextDocumentContentProvider('mo', {
+            provideTextDocumentContent(uri: Uri) {
+                const prefix = 'base/';
+                if (!uri.path.startsWith(prefix)) {
+                    return;
+                }
+                const path = uri.path.substring(prefix.length);
+                return (baseLibrary as Package).files[path]?.content ?? null;
             },
         }),
     );


### PR DESCRIPTION
Makes it possible to navigate the base library using virtual `mo:` URIs within VS Code. 

Improves the UX for go-to-definition when opening a project without a base library provided by Vessel or MOPS.
