### PR TITLE
Patch CVE-2022-46175

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6446,9 +6446,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+            "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -13981,9 +13981,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+            "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true
         },
         "keytar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "dependencies": {
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {


### PR DESCRIPTION
Patches [a recently discovered vulnerability](https://securityonline.info/cve-2022-46175-json5-prototype-pollution-vulnerability/) in the `json5` npm package, which is an indirect dependency for this extension. 