### PR TITLE
Implement 'organize imports' functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ Get this extension through the [VS Marketplace](https://marketplace.visualstudio
 - `motoko.formatter`: The formatter used by the extension
 - `motoko.legacyDfxSupport`: Uses legacy `dfx`-dependent features when a relevant `dfx.json` file is available
 
+## Advanced Configuration
+
+If you want VS Code to automatically format Motoko files on save, consider adding the following to your `settings.json` configuration:
+
+```json
+{
+  "[motoko]": {
+    "editor.defaultFormatter": "dfinity-foundation.vscode-motoko",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    }
+  }
+}
+```
+
 ## Recent Changes
 
 Projects using `dfx >= 0.11.1` use a new, experimental language server.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Get this extension through the [VS Marketplace](https://marketplace.visualstudio
 
 ## Extension Commands
 
-- `motoko.startService`: Starts (or restarts) the language service
+- `Motoko: Restart language server`: Starts (or restarts) the language server
 
 ## Extension Settings
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This extension provides syntax highlighting, type checking, and code formatting 
 - Automatic imports
 - Snippets ([contributions welcome](https://github.com/dfinity/node-motoko/blob/main/contrib/snippets.json))
 - Go-to-definition
+- Organize imports
 - Documentation tooltips
 
 ## Installation

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function startServer(context: ExtensionContext) {
 
     // Cross-platform language server
     const module = context.asAbsolutePath(path.join('out', 'server.js'));
-    launchClient(context, {
+    restartLanguageServer(context, {
         run: { module, transport: TransportKind.ipc },
         debug: {
             module,
@@ -92,7 +92,10 @@ function launchDfxProject(context: ExtensionContext, dfxConfig: DfxConfig) {
             command: getDfxPath(),
             args: ['_language-service', canister],
         };
-        launchClient(context, { run: serverCommand, debug: serverCommand });
+        restartLanguageServer(context, {
+            run: serverCommand,
+            debug: serverCommand,
+        });
     };
 
     const canister = config.get<string>('canister');
@@ -114,7 +117,10 @@ function launchDfxProject(context: ExtensionContext, dfxConfig: DfxConfig) {
     }
 }
 
-function launchClient(context: ExtensionContext, serverOptions: ServerOptions) {
+function restartLanguageServer(
+    context: ExtensionContext,
+    serverOptions: ServerOptions,
+) {
     if (client) {
         console.log('Restarting Motoko language server');
         client.stop().catch((err) => console.error(err.stack || err));

--- a/src/server/imports.ts
+++ b/src/server/imports.ts
@@ -271,10 +271,5 @@ export function organizeImports(imports: Import[]): string {
             }
         });
 
-    return formatMotoko(
-        groupParts
-            .map((p) => p.join('\n'))
-            .join('\n\n')
-            .trim(),
-    );
+    return formatMotoko(groupParts.map((p) => p.join('\n')).join('\n\n'));
 }

--- a/src/server/imports.ts
+++ b/src/server/imports.ts
@@ -202,22 +202,14 @@ function getImportInfo(
 const importGroups: {
     prefix: string;
 }[] = [
-    {
-        // IC imports
-        prefix: 'ic:',
-    },
-    {
-        // Canister alias imports
-        prefix: 'canister:',
-    },
-    {
-        // Package imports
-        prefix: 'mo:',
-    },
-    {
-        // Everything else
-        prefix: '',
-    },
+    // IC imports
+    { prefix: 'ic:' },
+    // Canister alias imports
+    { prefix: 'canister:' },
+    // Package imports
+    { prefix: 'mo:' },
+    // Everything else
+    { prefix: '' },
 ];
 
 export function organizeImports(imports: Import[]): string {

--- a/src/server/imports.ts
+++ b/src/server/imports.ts
@@ -2,8 +2,8 @@ import { pascalCase } from 'change-case';
 import { MultiMap } from 'mnemonist';
 import { AST, Node } from 'motoko/lib/ast';
 import { Context, getContext } from './context';
-import { Program, matchNode } from './syntax';
-import { getRelativeUri } from './utils';
+import { Import, Program, matchNode } from './syntax';
+import { formatMotoko, getRelativeUri } from './utils';
 
 interface ResolvedField {
     name: string;
@@ -197,4 +197,84 @@ function getImportInfo(
         return;
     }
     return [getImportName(uri), uri];
+}
+
+const importGroups: {
+    prefix: string;
+}[] = [
+    {
+        // IC imports
+        prefix: 'ic:',
+    },
+    {
+        // Canister alias imports
+        prefix: 'canister:',
+    },
+    {
+        // Package imports
+        prefix: 'mo:',
+    },
+    {
+        // Everything else
+        prefix: '',
+    },
+];
+
+export function organizeImports(imports: Import[]): string {
+    const groupParts: string[][] = importGroups.map(() => []);
+
+    // Combine imports with the same path
+    const combinedImports: Record<
+        string,
+        { names: string[]; fields: [string, string][] }
+    > = {};
+    imports.forEach((x) => {
+        const combined =
+            combinedImports[x.path] ||
+            (combinedImports[x.path] = { names: [], fields: [] });
+        if (x.name) {
+            combined.names.push(x.name);
+        }
+        combined.fields.push(...x.fields);
+    });
+
+    // Sort and print imports
+    Object.entries(combinedImports)
+        .sort(
+            // Sort by import path
+            (a, b) => a[0].localeCompare(b[0]),
+        )
+        .forEach(([path, { names, fields }]) => {
+            const parts =
+                groupParts[
+                    importGroups.findIndex((g) => path.startsWith(g.prefix))
+                ] || groupParts[groupParts.length - 1];
+            names.forEach((name) => {
+                parts.push(`import ${name} ${JSON.stringify(path)};`);
+            });
+            if (fields.length) {
+                parts.push(
+                    `import { ${fields
+                        .sort(
+                            // Sort by name, then alias
+                            (a, b) =>
+                                a[0].localeCompare(b[0]) ||
+                                (a[1] || a[0]).localeCompare(b[1] || b[0]),
+                        )
+                        .map(([name, alias]) =>
+                            !alias || name === alias
+                                ? name
+                                : `${name} = ${alias}`,
+                        )
+                        .join('; ')} } ${JSON.stringify(path)};`,
+                );
+            }
+        });
+
+    return formatMotoko(
+        groupParts
+            .map((p) => p.join('\n'))
+            .join('\n\n')
+            .trim(),
+    );
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -816,8 +816,11 @@ connection.onCodeAction((event) => {
             console.warn('Unexpected import AST range format');
             return;
         }
-        const range = Range.create(start, end);
-        const source = organizeImports(imports);
+        const range = Range.create(
+            Position.create(start.line, 0),
+            Position.create(end.line + 1, 0),
+        );
+        const source = organizeImports(imports).trim() + '\n';
         results.push({
             title: 'Organize imports',
             kind: CodeActionKind.SourceOrganizeImports,


### PR DESCRIPTION
Sorts and groups Motoko imports on pressing the ["Organize imports"](https://stackoverflow.com/questions/49919726/how-to-invoke-the-organize-imports-typescript-feature-in-visual-studio) key binding. 

Here is an overview of the current grouping and sorting rules:
- Sort alphabetically by path, import name, and then field name
- Move named module imports above explicit field imports for the same path
- Group by prefix (`ic:`, `canister:`, `mo:`, and then relative paths)

TODO:
- Automatically remove unused imports

Progress towards #123.