### PR TITLE
Resolve MOPS from local package.json dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "dependencies": {
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -102,7 +102,7 @@ async function getPackageSources(
     // Prioritize MOPS over Vessel
     if (existsSync(join(directory, 'mops.toml'))) {
         // const command = 'mops sources';
-        const command = 'npx --no-install ic-mops sources';
+        const command = 'npx --no -p ic-mops sources';
         try {
             return sourcesFromCommand(command);
         } catch (err: any) {
@@ -126,15 +126,21 @@ async function getPackageSources(
             // }
 
             throw new Error(
-                `Error while running \`${command}\`: ${err?.message || err}`,
+                `Error while finding MOPS packages.\nMake sure MOPS is installed (https://mops.one/docs/install).\n${
+                    err?.message || err
+                }`,
             );
         }
     } else if (existsSync(join(directory, 'vessel.dhall'))) {
         const command = 'vessel sources';
         try {
             return sourcesFromCommand(command);
-        } catch (err) {
-            console.error(`Error while running \`${command}\`:`, err);
+        } catch (err: any) {
+            console.error(
+                `Error while running \`${command}\`.\nMake sure Vessel is installed (https://github.com/dfinity/vessel/#getting-started).\n${
+                    err?.message || err
+                }`,
+            );
             return vesselSources(directory);
         }
     } else {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -126,7 +126,7 @@ async function getPackageSources(
             // }
 
             throw new Error(
-                `Error while finding MOPS packages.\nMake sure MOPS is installed (https://mops.one/docs/install).\n${
+                `Error while finding MOPS packages.\nMake sure MOPS is installed locally or globally (https://mops.one/docs/install).\n${
                     err?.message || err
                 }`,
             );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -102,7 +102,7 @@ async function getPackageSources(
     // Prioritize MOPS over Vessel
     if (existsSync(join(directory, 'mops.toml'))) {
         // const command = 'mops sources';
-        const command = 'npx --no -p ic-mops sources';
+        const command = 'npx --no ic-mops sources';
         try {
             return sourcesFromCommand(command);
         } catch (err: any) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -101,7 +101,8 @@ async function getPackageSources(
 
     // Prioritize MOPS over Vessel
     if (existsSync(join(directory, 'mops.toml'))) {
-        const command = 'mops sources';
+        // const command = 'mops sources';
+        const command = 'npx --no-install ic-mops sources';
         try {
             return sourcesFromCommand(command);
         } catch (err: any) {


### PR DESCRIPTION
Detects `ic-mops` from local or global npm dependencies instead of `mops` from the system path. This makes it possible to use different MOPS versions for individual projects. 
