### PR TITLE
Cache package sources during retry-on-save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",
                 "mnemonist": "0.39.5",
-                "motoko": "3.4.1",
+                "motoko": "3.4.3",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.3.2",
                 "url-relative": "1.0.0",
@@ -7100,9 +7100,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.4.1.tgz",
-            "integrity": "sha512-l5HTS26CgpmTcLZK/ouVZLPq9i/ogxtgaMC1dAawG2Jz9T/Rl2rneFnSQAAEQqIs46Ywo63k35EJgbS2ix9Aig==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.4.3.tgz",
+            "integrity": "sha512-WvhhBXuVMwyiu8yXl5+AmISMVfRUDFPLBzDL+GPk8T49zCJZMoc504ZoaEP3yyVGi9TpWWawoQn7ZT4b7Fb9Vg==",
             "dependencies": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
@@ -14455,9 +14455,9 @@
             }
         },
         "motoko": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.4.1.tgz",
-            "integrity": "sha512-l5HTS26CgpmTcLZK/ouVZLPq9i/ogxtgaMC1dAawG2Jz9T/Rl2rneFnSQAAEQqIs46Ywo63k35EJgbS2ix9Aig==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.4.3.tgz",
+            "integrity": "sha512-WvhhBXuVMwyiu8yXl5+AmISMVfRUDFPLBzDL+GPk8T49zCJZMoc504ZoaEP3yyVGi9TpWWawoQn7ZT4b7Fb9Vg==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.8.4",
+            "version": "0.8.5",
             "dependencies": {
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "change-case": "4.1.2",
         "fast-glob": "3.2.12",
         "mnemonist": "0.39.5",
-        "motoko": "3.4.1",
+        "motoko": "3.4.3",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.3.2",
         "url-relative": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -70,6 +70,7 @@ const ignoreGlobs = [
     '**/.vessel/.tmp/**/*', // temporary Vessel files
 ];
 
+const packageSourceCache = new Map();
 async function getPackageSources(
     directory: string,
 ): Promise<[string, string][]> {
@@ -101,6 +102,14 @@ async function getPackageSources(
         return sources;
     }
 
+    // Prioritize cached sources
+    const cached = packageSourceCache.get(directory);
+    if (cached) {
+        return cached;
+    }
+
+    let sources: [string, string][] = [];
+
     // Prioritize `defaults.build.packtool`
     const dfxPath = join(directory, 'dfx.json');
     if (existsSync(dfxPath)) {
@@ -108,7 +117,7 @@ async function getPackageSources(
             const dfxConfig = JSON.parse(readFileSync(dfxPath, 'utf8'));
             const command = dfxConfig?.defaults?.build?.packtool;
             if (command) {
-                return sourcesFromCommand(command);
+                sources = await sourcesFromCommand(command);
             }
         } catch (err: any) {
             throw new Error(
@@ -124,7 +133,7 @@ async function getPackageSources(
         // const command = 'mops sources';
         const command = 'npx --no ic-mops sources';
         try {
-            return sourcesFromCommand(command);
+            sources = await sourcesFromCommand(command);
         } catch (err: any) {
             // try {
             //     const sources = await mopsSources(directory);
@@ -154,7 +163,7 @@ async function getPackageSources(
     } else if (existsSync(join(directory, 'vessel.dhall'))) {
         const command = 'vessel sources';
         try {
-            return sourcesFromCommand(command);
+            sources = await sourcesFromCommand(command);
         } catch (err: any) {
             throw new Error(
                 `Error while running \`${command}\`.\nMake sure Vessel is installed (https://github.com/dfinity/vessel/#getting-started).\n${
@@ -163,15 +172,22 @@ async function getPackageSources(
             );
             // return vesselSources(directory);
         }
-    } else {
-        return [];
     }
+    // else {
+    //     sources = [];
+    // }
+
+    packageSourceCache.set(directory, sources);
+    return sources;
 }
 
 let loadingPackages = false;
 let packageConfigError = false;
 let packageConfigChangeTimeout: ReturnType<typeof setTimeout>;
-function notifyPackageConfigChange() {
+function notifyPackageConfigChange(retry = false) {
+    if (!retry) {
+        packageSourceCache.clear();
+    }
     clearTimeout(packageConfigChangeTimeout);
     loadingPackages = true;
     setTimeout(async () => {
@@ -182,13 +198,15 @@ function notifyPackageConfigChange() {
             const directories: string[] = [];
             try {
                 workspaceFolders?.forEach((workspaceFolder) => {
-                    const filenames = ['mops.toml', 'vessel.dhall'];
+                    const filenames = ['mops.toml', 'vessel.dhall', 'dfx.json'];
+                    const cwd = resolveFilePath(workspaceFolder.uri);
                     const paths = glob.sync(`**/{${filenames.join(',')}}`, {
-                        cwd: resolveFilePath(workspaceFolder.uri),
+                        cwd,
                         ignore: ignoreGlobs,
                         dot: false,
                     });
                     paths.forEach((path) => {
+                        path = join(cwd, path);
                         filenames.forEach((filename) => {
                             if (path.endsWith(filename)) {
                                 const dir = resolve(
@@ -1178,7 +1196,7 @@ let validatingTimeout: ReturnType<typeof setTimeout>;
 let validatingUri: string | undefined;
 documents.onDidChangeContent((event) => {
     if (packageConfigError) {
-        notifyPackageConfigChange();
+        notifyPackageConfigChange(true);
     }
     const document = event.document;
     const { uri } = document;


### PR DESCRIPTION
If an error occurs while loading package sources, the extension will now cache successful results when more than one package context (e.g. `mops.toml` or `vessel.dhall` file) exists in the workspace. 

Addresses #164.