### PR TITLE
Improve performance for large workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "mnemonist": "0.39.5",
                 "motoko": "3.4.3",
                 "prettier": "2.8.0",
-                "prettier-plugin-motoko": "0.3.2",
+                "prettier-plugin-motoko": "0.3.3",
                 "url-relative": "1.0.0",
                 "vscode-languageclient": "8.0.2",
                 "vscode-languageserver": "8.0.2",
@@ -7751,9 +7751,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.2.tgz",
-            "integrity": "sha512-wcncL6g9HKLCfWdPXOv9Aj5WMcGJSldbzCuc95N1tKCdTG0UHKi0QRy/GS8WppvFwt8+CCZNDkaHU7qM/grLWQ==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.3.tgz",
+            "integrity": "sha512-8WIRLkPjR8AejZvp7fIuWhTGHn1YuBBjn/wqcREc+0EmipnD++Lbs+3TxVjI7aOi5NhvkRZIsSclTRTgrgXdeg==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -14951,9 +14951,9 @@
             "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.2.tgz",
-            "integrity": "sha512-wcncL6g9HKLCfWdPXOv9Aj5WMcGJSldbzCuc95N1tKCdTG0UHKi0QRy/GS8WppvFwt8+CCZNDkaHU7qM/grLWQ==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.3.tgz",
+            "integrity": "sha512-8WIRLkPjR8AejZvp7fIuWhTGHn1YuBBjn/wqcREc+0EmipnD++Lbs+3TxVjI7aOi5NhvkRZIsSclTRTgrgXdeg==",
             "requires": {}
         },
         "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.8.5",
+    "version": "0.9.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.8.5",
+            "version": "0.9.0",
             "dependencies": {
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         "mnemonist": "0.39.5",
         "motoko": "3.4.3",
         "prettier": "2.8.0",
-        "prettier-plugin-motoko": "0.3.2",
+        "prettier-plugin-motoko": "0.3.3",
         "url-relative": "1.0.0",
         "vscode-languageclient": "8.0.2",
         "vscode-languageserver": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.8.5",
+    "version": "0.9.0",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {


### PR DESCRIPTION
This PR changes the extension to only type-check active tabs and canister entry points, providing a giant performance boost (on the order of 100x) for large-scale Motoko workspaces.