### PR TITLE
Improve performance when using autosave

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -682,7 +682,7 @@ function checkWorkspace() {
             console.error('Error while finding dfx canister paths');
             console.error(err);
         }
-    }, 500);
+    }, 1000);
 }
 
 // /**

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -506,6 +506,7 @@ connection.onDidChangeWatchedFiles((event) => {
             } else {
                 notify(change.uri);
             }
+
             if (
                 change.uri.endsWith('.did') ||
                 change.uri.endsWith('/dfx.json')
@@ -1220,12 +1221,12 @@ documents.onDidChangeContent((event) => {
     if (uri === validatingUri) {
         clearTimeout(validatingTimeout);
     }
+    validatingUri = uri;
     validatingTimeout = setTimeout(() => {
         validate(document);
         const { astResolver } = getContext(uri);
         astResolver.update(uri, true); /// TODO: also use for type checking?
     }, 100);
-    validatingUri = uri;
 });
 
 documents.onDidOpen((event) => scheduleCheck(event.document.uri));


### PR DESCRIPTION
Increases the debounce time between autosaving and type checking all canister entry points in the workspace (500 -> 1000 ms). 