### PR TITLE
Always prioritize package source command from dfx.json file

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -682,7 +682,7 @@ function checkWorkspace() {
             console.error('Error while finding dfx canister paths');
             console.error(err);
         }
-    }, 500);
+    }, 1000);
 }
 
 // /**

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -506,6 +506,7 @@ connection.onDidChangeWatchedFiles((event) => {
             } else {
                 notify(change.uri);
             }
+
             if (
                 change.uri.endsWith('.did') ||
                 change.uri.endsWith('/dfx.json')
@@ -1220,12 +1221,12 @@ documents.onDidChangeContent((event) => {
     if (uri === validatingUri) {
         clearTimeout(validatingTimeout);
     }
+    validatingUri = uri;
     validatingTimeout = setTimeout(() => {
         validate(document);
         const { astResolver } = getContext(uri);
         astResolver.update(uri, true); /// TODO: also use for type checking?
     }, 100);
-    validatingUri = uri;
 });
 
 documents.onDidOpen((event) => scheduleCheck(event.document.uri));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -128,54 +128,53 @@ async function getPackageSources(
         }
     }
 
-    // Prioritize MOPS over Vessel
-    if (existsSync(join(directory, 'mops.toml'))) {
-        // const command = 'mops sources';
-        const command = 'npx --no ic-mops sources';
-        try {
-            sources = await sourcesFromCommand(command);
-        } catch (err: any) {
-            // try {
-            //     const sources = await mopsSources(directory);
-            //     if (!sources) {
-            //         throw new Error('Unexpected output');
-            //     }
-            //     return Object.entries(sources);
-            // } catch (fallbackError) {
-            //     console.error(
-            //         `Error in fallback MOPS implementation:`,
-            //         fallbackError,
-            //     );
-            //     // Provide a verbose error message for MOPS command
-            //     throw new Error(
-            //         `Error while running \`${command}\`: ${
-            //             err?.message || err
-            //         }`,
-            //     );
-            // }
+    if (!sources) {
+        // Prioritize MOPS over Vessel
+        if (existsSync(join(directory, 'mops.toml'))) {
+            // const command = 'mops sources';
+            const command = 'npx --no ic-mops sources';
+            try {
+                sources = await sourcesFromCommand(command);
+            } catch (err: any) {
+                // try {
+                //     const sources = await mopsSources(directory);
+                //     if (!sources) {
+                //         throw new Error('Unexpected output');
+                //     }
+                //     return Object.entries(sources);
+                // } catch (fallbackError) {
+                //     console.error(
+                //         `Error in fallback MOPS implementation:`,
+                //         fallbackError,
+                //     );
+                //     // Provide a verbose error message for MOPS command
+                //     throw new Error(
+                //         `Error while running \`${command}\`: ${
+                //             err?.message || err
+                //         }`,
+                //     );
+                // }
 
-            throw new Error(
-                `Error while finding MOPS packages.\nMake sure MOPS is installed locally or globally (https://mops.one/docs/install).\n${
-                    err?.message || err
-                }`,
-            );
-        }
-    } else if (existsSync(join(directory, 'vessel.dhall'))) {
-        const command = 'vessel sources';
-        try {
-            sources = await sourcesFromCommand(command);
-        } catch (err: any) {
-            throw new Error(
-                `Error while running \`${command}\`.\nMake sure Vessel is installed (https://github.com/dfinity/vessel/#getting-started).\n${
-                    err?.message || err
-                }`,
-            );
-            // return vesselSources(directory);
+                throw new Error(
+                    `Error while finding MOPS packages.\nMake sure MOPS is installed locally or globally (https://mops.one/docs/install).\n${
+                        err?.message || err
+                    }`,
+                );
+            }
+        } else if (existsSync(join(directory, 'vessel.dhall'))) {
+            const command = 'vessel sources';
+            try {
+                sources = await sourcesFromCommand(command);
+            } catch (err: any) {
+                throw new Error(
+                    `Error while running \`${command}\`.\nMake sure Vessel is installed (https://github.com/dfinity/vessel/#getting-started).\n${
+                        err?.message || err
+                    }`,
+                );
+                // return vesselSources(directory);
+            }
         }
     }
-    // else {
-    //     sources = [];
-    // }
 
     packageSourceCache.set(directory, sources);
     return sources;


### PR DESCRIPTION
Fixes a bug which causes a Vessel or MOPS configuration file to override the source command defined by an adjacent `dfx.json` file. 