### PR TITLE
Bump moc to 0.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "dependencies": {
                 "@wasmer/wasi": "^1.2.2",
                 "change-case": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "mnemonist": "0.39.5",
                 "motoko": "3.5.1",
                 "prettier": "2.8.0",
-                "prettier-plugin-motoko": "0.3.4",
+                "prettier-plugin-motoko": "0.3.5",
                 "url-relative": "1.0.0",
                 "vscode-languageclient": "8.0.2",
                 "vscode-languageserver": "8.0.2",
@@ -7421,9 +7421,9 @@
             }
         },
         "node_modules/prettier-plugin-motoko": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.4.tgz",
-            "integrity": "sha512-Yb6wxFOvBhf3Sd5l9Pq+L0hfyEIeo8SfJ2ohSgLuJ8cJ71MiJ8EI5+/yCuBBCup2FmKGsVAOMrLUFdLZwfftQg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.5.tgz",
+            "integrity": "sha512-ooEYebiaRtidYCYrouA4jwSRNngeJITloDhArsKG9oAgC0Qaz4kyhotHtACOfJegaiEF2YIibDKaQuHs4Qu/QA==",
             "peerDependencies": {
                 "prettier": "^2.7"
             }
@@ -14479,9 +14479,9 @@
             "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
         },
         "prettier-plugin-motoko": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.4.tgz",
-            "integrity": "sha512-Yb6wxFOvBhf3Sd5l9Pq+L0hfyEIeo8SfJ2ohSgLuJ8cJ71MiJ8EI5+/yCuBBCup2FmKGsVAOMrLUFdLZwfftQg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-motoko/-/prettier-plugin-motoko-0.3.5.tgz",
+            "integrity": "sha512-ooEYebiaRtidYCYrouA4jwSRNngeJITloDhArsKG9oAgC0Qaz4kyhotHtACOfJegaiEF2YIibDKaQuHs4Qu/QA==",
             "requires": {}
         },
         "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "change-case": "4.1.2",
                 "fast-glob": "3.2.12",
                 "mnemonist": "0.39.5",
-                "motoko": "3.5.1",
+                "motoko": "3.5.2",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.3.5",
                 "url-relative": "1.0.0",
@@ -6770,9 +6770,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.5.1.tgz",
-            "integrity": "sha512-by7GgEnoiC6pjR3LQJpqwDEJx760rbO1BRIpP38ACa7Nmm9xh3duJh5FuykdlZW1795TdRo4LYAoOroQ9lp74A==",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.5.2.tgz",
+            "integrity": "sha512-QDPVEVP0paj4BgFyWIQiqV7hg1mHSz4kjxSRyl1xZgo/GLrlbA6+l9z9tlu91HA07yAMz/KUC4bVMEo9/gNiqQ==",
             "dependencies": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
@@ -13983,9 +13983,9 @@
             }
         },
         "motoko": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.5.1.tgz",
-            "integrity": "sha512-by7GgEnoiC6pjR3LQJpqwDEJx760rbO1BRIpP38ACa7Nmm9xh3duJh5FuykdlZW1795TdRo4LYAoOroQ9lp74A==",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.5.2.tgz",
+            "integrity": "sha512-QDPVEVP0paj4BgFyWIQiqV7hg1mHSz4kjxSRyl1xZgo/GLrlbA6+l9z9tlu91HA07yAMz/KUC4bVMEo9/gNiqQ==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "change-case": "4.1.2",
         "fast-glob": "3.2.12",
         "mnemonist": "0.39.5",
-        "motoko": "3.5.1",
+        "motoko": "3.5.2",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.3.5",
         "url-relative": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
         "mnemonist": "0.39.5",
         "motoko": "3.5.1",
         "prettier": "2.8.0",
-        "prettier-plugin-motoko": "0.3.4",
+        "prettier-plugin-motoko": "0.3.5",
         "url-relative": "1.0.0",
         "vscode-languageclient": "8.0.2",
         "vscode-languageserver": "8.0.2",


### PR DESCRIPTION
Updates the bundled compiler and ships a bugfix for https://github.com/dfinity/motoko/issues/3822.