### PR TITLE
Improve tokenization for operators with `<` and `>`

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -9,8 +9,7 @@
     "brackets": [
         ["{", "}"],
         ["[", "]"],
-        ["(", ")"],
-        ["<", ">"]
+        ["(", ")"]
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
@@ -19,7 +18,6 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"]
-        // ["<", ">"]
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.10.1",
+            "version": "0.10.2",
             "dependencies": {
                 "@wasmer/wasi": "^1.2.2",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/syntaxes/Major.tmLanguage
+++ b/syntaxes/Major.tmLanguage
@@ -113,7 +113,7 @@
 		<key>assignment-operator</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(\+|\-|\*|\/|%|&lt;&lt;|&gt;&gt;|&amp;|\^|\||&amp;&amp;|\|\|)?=(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(\+|\-|\*|\/|%|&lt;&lt;&gt;?|&lt;?&gt;&gt;|&amp;|\^|\||&amp;&amp;|\|\|)?=(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.motoko</string>
 		</dict>
@@ -188,7 +188,7 @@
 		<key>bitwise-operator</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(&amp;|\||\^|&lt;&lt;|&gt;&gt;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(&amp;|\||\^|&lt;&lt;&gt;?|&lt;?&gt;&gt;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.bitwise.motoko</string>
 		</dict>


### PR DESCRIPTION
Fixes a regression which causes `<` and `>` characters to render as unclosed pairs when imbalanced. 