### PR TITLE
Update unit test convention for compatibility with `mo-test`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.10.5",
+            "version": "0.10.6",
             "dependencies": {
                 "@wasmer/wasi": "^1.2.2",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1228,7 +1228,7 @@ connection.onRequest(
                     stdout: output.stdout,
                     stderr: output.stderr,
                 };
-            } else if (mode === 'wasmer') {
+            } else if (mode === 'wasi') {
                 // Run tests via Wasmer
                 const start = Date.now();
                 const wasiResult = motoko.wasm(virtualPath, 'wasi');


### PR DESCRIPTION
Replaces `// @testmode wasmer` with `// @testmode wasi` for compatibility with the upcoming `mo-test` command.

Context: https://github.com/dfinity/motoko-dev-server/pull/18.