### PR TITLE
Add support for WSL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko-viper",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko-viper",
-            "version": "0.0.4",
+            "version": "0.1.0",
             "dependencies": {
                 "@viperproject/locate-java-home": "1.1.10",
                 "change-case": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko-viper",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko-viper",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "dependencies": {
                 "@viperproject/locate-java-home": "1.1.10",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "motoko-viper",
     "displayName": "Motoko-san",
     "description": "Experimental formal verification support for Motoko",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko/tree/viper",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "motoko-viper",
     "displayName": "Motoko-san",
     "description": "Experimental formal verification support for Motoko",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko/tree/viper",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,6 @@ import {
     TransportKind,
 } from 'vscode-languageclient/node';
 import { watchGlob } from './common/watchConfig';
-import { existsSync, fstat } from 'fs';
 
 // const config = workspace.getConfiguration('motoko');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import {
     ExtensionContext,
     Uri,
     commands,
+    env,
     extensions,
     window,
     workspace,
@@ -19,6 +20,7 @@ import {
     TransportKind,
 } from 'vscode-languageclient/node';
 import { watchGlob } from './common/watchConfig';
+import { existsSync, fstat } from 'fs';
 
 // const config = workspace.getConfiguration('motoko');
 
@@ -187,6 +189,13 @@ export async function startServer(context: ExtensionContext) {
             viperTools = viperTools.replace(
                 /\/Local\/ViperTools$/,
                 `/${buildVersion}/ViperTools`,
+            );
+        }
+        // WSL tweak
+        if (env.remoteName === 'wsl') {
+            viperTools = viperTools.replace(
+                path.join(homePath, '.config', 'Code'),
+                path.join(homePath, '.vscode-server', 'data'),
             );
         }
         // Codium tweak

--- a/src/server/viper.ts
+++ b/src/server/viper.ts
@@ -104,6 +104,13 @@ try {
                     verificationCompleted,
                     time,
                 }) => {
+                    console.log(
+                        '[Viper] state change:',
+                        diagnostics,
+                        newState,
+                        verificationCompleted,
+                        time,
+                    );
                     try {
                         if (!uri) {
                             return;


### PR DESCRIPTION
This PR includes a patch for the `viperTools` path so that the Motoko-san extension will work by default on [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). 

Context: [this forum conversation](https://forum.dfinity.org/t/motoko-san-code-level-verification-in-motoko/18171/3)