### PR TITLE
Fix 'catch' and 'do' keyword highlighting in VS Code 1.78+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.12.1",
+            "version": "0.12.2",
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/syntaxes/Major.tmLanguage
+++ b/syntaxes/Major.tmLanguage
@@ -242,15 +242,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>catch-statement-keyword</key>
-		<dict>
-			<key>comment</key>
-			<string>catch-statement</string>
-			<key>match</key>
-			<string>\b(catch|do)\b</string>
-			<key>name</key>
-			<string>kewyord.control.catch.motoko</string>
-		</dict>
 		<key>code-block</key>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
Fixes #212.