### PR TITLE
Update "canister alias not defined" error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.13.2",
+    "version": "0.13.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.13.2",
+            "version": "0.13.3",
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.13.2",
+    "version": "0.13.3",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -763,7 +763,7 @@ function checkImmediate(uri: string | TextDocument): boolean {
                     // Extra debugging information for `canister:` import errors
                     diagnostic = {
                         ...diagnostic,
-                        message: `${diagnostic.message}. This is usually fixed by running \`dfx deploy\``,
+                        message: `${diagnostic.message}. This is usually fixed by running \`dfx deploy\` or adding \`dependencies\` in your dfx.json file`,
                     };
                 }
 


### PR DESCRIPTION
Suggests adding canister dependencies in `dfx.json`, which is another common cause of the "canister alias not defined" error message. 