### PR TITLE
Skip symbolic links when loading workspace files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.13.5",
+            "version": "0.13.6",
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -217,6 +217,7 @@ function notifyPackageConfigChange(reuseCached = false) {
                         cwd,
                         ignore: ignoreGlobs,
                         dot: false,
+                        followSymbolicLinks: false,
                     });
                     paths.forEach((path) => {
                         path = join(cwd, path);
@@ -529,6 +530,7 @@ function notifyWorkspace() {
             cwd: folderPath,
             dot: true,
             ignore: ignoreGlobs,
+            followSymbolicLinks: false,
         }).forEach((relativePath) => {
             const path = join(folderPath, relativePath);
             try {
@@ -610,6 +612,7 @@ function checkWorkspace() {
             //         cwd: folderPath,
             //         dot: false, // exclude directories such as `.vessel`
             //         ignore: ignoreGlobs,
+            //         followSymbolicLinks: false,
             //     }).forEach((relativePath) => {
             //         const path = join(folderPath, relativePath);
             //         try {


### PR DESCRIPTION
Fixes a glob pattern corner case involving recursive symbolic links raised in #223. 
