### PR TITLE
Support all assignment patterns in outline and go-to-symbol

### DIFF
--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -107,6 +107,7 @@ export function locationFromDefinition(definition: Definition) {
     return location;
 }
 
+// TODO: refactor to use `findInPattern()`
 function findNameInPattern(search: Search, pat: Node): Node | undefined {
     const matchAny = (...args: Node[]) => {
         for (const field of args) {

--- a/src/server/syntax.spec.ts
+++ b/src/server/syntax.spec.ts
@@ -90,4 +90,14 @@ describe('syntax', () => {
         const fields = expectWithFields(prog.exportFields[0].exp, [undefined]);
         expectWithFields(fields[0].exp, ['x']);
     });
+    test('tuple pattern', () => {
+        const prog = parse('module { let (a, b) = ("a", "b"); }');
+        expectFields(prog.exportFields, [undefined]);
+        expectWithFields(prog.exportFields[0].exp, ['a', 'b']);
+    });
+    test('object pattern', () => {
+        const prog = parse('module { let { a; b } = { a = "a"; b = "b" }; }');
+        expectFields(prog.exportFields, [undefined]);
+        expectWithFields(prog.exportFields[0].exp, ['a', 'b']);
+    });
 });


### PR DESCRIPTION
Includes complex assignments such as `let (a, b) = tuple` or `let { x } = object` in both the outline and go-to-symbol interfaces. 