### PR TITLE
Improve formatting with Prettier 3.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.14.1",
+            "version": "0.14.2",
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",
                 "change-case": "4.1.2",
@@ -14,7 +14,7 @@
                 "ic-mops": "0.26.3",
                 "ic0": "0.2.7",
                 "mnemonist": "0.39.5",
-                "motoko": "3.6.7",
+                "motoko": "3.6.9",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.8.1",
                 "url-relative": "1.0.0",
@@ -70,12 +70,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-            "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.18.6"
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -130,13 +131,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
-            "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.3",
+                "@babel/types": "^7.23.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -185,34 +187,34 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-            "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.18.10",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-            "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -271,30 +273,30 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-            "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-            "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -324,13 +326,13 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-            "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "chalk": "^2.0.0",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             },
             "engines": {
@@ -338,9 +340,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
-            "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -527,33 +529,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
-            "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.3",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-hoist-variables": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.3",
-                "@babel/types": "^7.19.3",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -562,13 +564,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
-            "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.18.10",
-                "@babel/helper-validator-identifier": "^7.19.1",
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -1620,13 +1622,13 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@noble/hashes": {
@@ -8520,9 +8522,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.6.7",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.7.tgz",
-            "integrity": "sha512-EUtgc4nEZkM/A+8HzHjcxrLK+U9LuuRiApRWGu/Wj0fmiHikUhGKQFGGYMxl9/4wyEiLK+KYcGnl882Z7KcwIQ==",
+            "version": "3.6.9",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.9.tgz",
+            "integrity": "sha512-x7UmmqcCCxNUvFnu3K6csrsVoFIEJdiRFT7oBwro6mHiPelQ4kU5P0aWTJERn4qbJiGqnDjKipP0X86h2g0qyw==",
             "dependencies": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
@@ -11269,12 +11271,13 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-            "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.18.6"
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
             }
         },
         "@babel/compat-data": {
@@ -11315,13 +11318,14 @@
             }
         },
         "@babel/generator": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
-            "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.3",
+                "@babel/types": "^7.23.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
             },
             "dependencies": {
@@ -11359,28 +11363,28 @@
             }
         },
         "@babel/helper-environment-visitor": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true
         },
         "@babel/helper-function-name": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-            "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.18.10",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-            "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             }
         },
         "@babel/helper-module-imports": {
@@ -11424,24 +11428,24 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-            "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.22.5"
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-            "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true
         },
         "@babel/helper-validator-option": {
@@ -11462,20 +11466,20 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-            "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "chalk": "^2.0.0",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
-            "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -11605,42 +11609,42 @@
             }
         },
         "@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
             }
         },
         "@babel/traverse": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
-            "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.3",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-hoist-variables": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.3",
-                "@babel/types": "^7.19.3",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
-            "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.18.10",
-                "@babel/helper-validator-identifier": "^7.19.1",
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -12422,13 +12426,13 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
             "dev": true,
             "requires": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "@noble/hashes": {
@@ -17436,9 +17440,9 @@
             }
         },
         "motoko": {
-            "version": "3.6.7",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.7.tgz",
-            "integrity": "sha512-EUtgc4nEZkM/A+8HzHjcxrLK+U9LuuRiApRWGu/Wj0fmiHikUhGKQFGGYMxl9/4wyEiLK+KYcGnl882Z7KcwIQ==",
+            "version": "3.6.9",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.9.tgz",
+            "integrity": "sha512-x7UmmqcCCxNUvFnu3K6csrsVoFIEJdiRFT7oBwro6mHiPelQ4kU5P0aWTJERn4qbJiGqnDjKipP0X86h2g0qyw==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {
@@ -172,7 +172,7 @@
         "ic-mops": "0.26.3",
         "ic0": "0.2.7",
         "mnemonist": "0.39.5",
-        "motoko": "3.6.7",
+        "motoko": "3.6.9",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.8.1",
         "url-relative": "1.0.0",

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -16,50 +16,53 @@ export function formatDocument(
     _context: ExtensionContext,
     options: FormattingOptions,
 ): TextEdit[] {
-    const formatter = workspace
-        .getConfiguration('motoko')
-        .get<string>('formatter');
-    if (formatter === 'prettier') {
-        const rootPath = getCurrentWorkspaceRootFsPath();
-        if (rootPath) {
-            const ignoreOptions = {
-                ignorePath: join(rootPath, '.prettierignore'),
-            };
-            const fileInfo = prettier.getFileInfo.sync(
-                document.uri.fsPath,
-                ignoreOptions,
-            );
-            if (!fileInfo.ignored) {
-                const source = document.getText();
-
-                const config = prettier.resolveConfig.sync(
-                    document.uri.fsPath /* , options */,
-                );
-                if (config !== null) {
-                    prettier.clearConfigCache();
-                }
-                const prettierOptions: prettier.Options = {
-                    filepath: document.fileName,
-                    // pluginSearchDirs: [join(rootPath, 'node_modules')],
-                    plugins: [motokoPlugin],
-                    tabWidth: options.tabSize,
-                    useTabs: !options.insertSpaces,
-                    ...(config || {}),
+    try {
+        const formatter = workspace
+            .getConfiguration('motoko')
+            .get<string>('formatter');
+        if (formatter === 'prettier') {
+            const rootPath = getCurrentWorkspaceRootFsPath();
+            if (rootPath) {
+                const ignoreOptions = {
+                    ignorePath: join(rootPath, '.prettierignore'),
                 };
-                // Object.assign(options, config);
-                const firstLine = document.lineAt(0);
-                const lastLine = document.lineAt(document.lineCount - 1);
-                const fullTextRange = new Range(
-                    firstLine.range.start,
-                    lastLine.range.end,
+                const fileInfo = prettier.getFileInfo.sync(
+                    document.uri.fsPath,
+                    ignoreOptions,
                 );
-                const formatted = prettier.format(source, prettierOptions);
-                if (!formatted) {
-                    return [];
+                if (!fileInfo.ignored) {
+                    const source = document.getText();
+
+                    const config = prettier.resolveConfig.sync(
+                        document.uri.fsPath /* , options */,
+                    );
+                    if (config !== null) {
+                        prettier.clearConfigCache();
+                    }
+                    const prettierOptions: prettier.Options = {
+                        filepath: document.fileName,
+                        // pluginSearchDirs: [join(rootPath, 'node_modules')],
+                        tabWidth: options.tabSize,
+                        useTabs: !options.insertSpaces,
+                        ...(config || {}),
+                        plugins: [motokoPlugin],
+                    };
+                    const firstLine = document.lineAt(0);
+                    const lastLine = document.lineAt(document.lineCount - 1);
+                    const fullTextRange = new Range(
+                        firstLine.range.start,
+                        lastLine.range.end,
+                    );
+                    const formatted = prettier.format(source, prettierOptions);
+                    if (!formatted) {
+                        return [];
+                    }
+                    return [TextEdit.replace(fullTextRange, formatted)];
                 }
-                return [TextEdit.replace(fullTextRange, formatted)];
             }
         }
+    } catch (err) {
+        console.error('Error while formatting:', err);
     }
     return [];
 }


### PR DESCRIPTION
This PR fixes several corner cases which are frequently encountered while upgrading from Prettier 2.x to 3.x in a local npm project. 

Since the VS Code extension uses Prettier 2 while local projects use Prettier 3, it was possible for plugins intended for the latest version to cause errors while using the IDE formatter. The extension now always uses a built-in Motoko plugin which works for both Prettier versions. 