### PR TITLE
Support canister aliases for `pull` dependencies and direct imports of management canister

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.14.8",
+    "version": "0.15.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.14.8",
+            "version": "0.15.0",
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",
                 "change-case": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.14.8",
+    "version": "0.15.0",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/candid/aaaaa-aa.did.ts
+++ b/src/candid/aaaaa-aa.did.ts
@@ -1,0 +1,229 @@
+export default `
+type canister_id = principal;
+type wasm_module = blob;
+
+type canister_settings = record {
+  controllers : opt vec principal;
+  compute_allocation : opt nat;
+  memory_allocation : opt nat;
+  freezing_threshold : opt nat;
+};
+
+type definite_canister_settings = record {
+  controllers : vec principal;
+  compute_allocation : nat;
+  memory_allocation : nat;
+  freezing_threshold : nat;
+};
+
+type change_origin = variant {
+  from_user : record {
+    user_id : principal;
+  };
+  from_canister : record {
+    canister_id : principal;
+    canister_version : opt nat64;
+  };
+};
+
+type change_details = variant {
+  creation : record {
+    controllers : vec principal;
+  };
+  code_uninstall;
+  code_deployment : record {
+    mode : variant {install; reinstall; upgrade};
+    module_hash : blob;
+  };
+  controllers_change : record {
+    controllers : vec principal;
+  };
+};
+
+type change = record {
+  timestamp_nanos : nat64;
+  canister_version : nat64;
+  origin : change_origin;
+  details : change_details;
+};
+
+type chunk_hash = blob;
+
+type http_header = record { name: text; value: text };
+
+type http_response = record {
+  status: nat;
+  headers: vec http_header;
+  body: blob;
+};
+
+type ecdsa_curve = variant { secp256k1; };
+
+type satoshi = nat64;
+
+type bitcoin_network = variant {
+  mainnet;
+  testnet;
+};
+
+type bitcoin_address = text;
+
+type block_hash = blob;
+
+type outpoint = record {
+  txid : blob;
+  vout : nat32
+};
+
+type utxo = record {
+  outpoint: outpoint;
+  value: satoshi;
+  height: nat32;
+};
+
+type get_utxos_request = record {
+  address : bitcoin_address;
+  network: bitcoin_network;
+  filter: opt variant {
+    min_confirmations: nat32;
+    page: blob;
+  };
+};
+
+type get_current_fee_percentiles_request = record {
+  network: bitcoin_network;
+};
+
+type get_utxos_response = record {
+  utxos: vec utxo;
+  tip_block_hash: block_hash;
+  tip_height: nat32;
+  next_page: opt blob;
+};
+
+type get_balance_request = record {
+  address : bitcoin_address;
+  network: bitcoin_network;
+  min_confirmations: opt nat32;
+};
+
+type send_transaction_request = record {
+  transaction: blob;
+  network: bitcoin_network;
+};
+
+type millisatoshi_per_byte = nat64;
+
+service ic : {
+  create_canister : (record {
+    settings : opt canister_settings;
+    sender_canister_version : opt nat64;
+  }) -> (record {canister_id : canister_id});
+  update_settings : (record {
+    canister_id : principal;
+    settings : canister_settings;
+    sender_canister_version : opt nat64;
+  }) -> ();
+  upload_chunk : (record {
+    canister_id : principal;
+    chunk : blob;
+  }) -> (chunk_hash);
+  clear_chunk_store: (record {canister_id : canister_id}) -> ();
+  stored_chunks: (record {canister_id : canister_id}) -> (vec chunk_hash);
+  install_code : (record {
+    mode : variant {
+      install;
+      reinstall;
+      upgrade : opt record {
+        skip_pre_upgrade: opt bool;
+      }
+    };
+    canister_id : canister_id;
+    wasm_module : wasm_module;
+    arg : blob;
+    sender_canister_version : opt nat64;
+  }) -> ();
+  install_chunked_code: (record {
+    mode : variant {
+      install;
+      reinstall;
+      upgrade : opt record {
+        skip_pre_upgrade: opt bool;
+      };
+    };
+    target_canister: canister_id;
+    storage_canister: opt canister_id;
+    chunk_hashes_list: vec chunk_hash;
+    wasm_module_hash: blob;
+    arg : blob;
+    sender_canister_version : opt nat64;
+  }) -> ();
+  uninstall_code : (record {
+    canister_id : canister_id;
+    sender_canister_version : opt nat64;
+  }) -> ();
+  start_canister : (record {canister_id : canister_id}) -> ();
+  stop_canister : (record {canister_id : canister_id}) -> ();
+  canister_status : (record {canister_id : canister_id}) -> (record {
+      status : variant { running; stopping; stopped };
+      settings: definite_canister_settings;
+      module_hash: opt blob;
+      memory_size: nat;
+      cycles: nat;
+      idle_cycles_burned_per_day: nat;
+  });
+  canister_info : (record {
+      canister_id : canister_id;
+      num_requested_changes : opt nat64;
+  }) -> (record {
+      total_num_changes : nat64;
+      recent_changes : vec change;
+      module_hash : opt blob;
+      controllers : vec principal;
+  });
+  delete_canister : (record {canister_id : canister_id}) -> ();
+  deposit_cycles : (record {canister_id : canister_id}) -> ();
+  raw_rand : () -> (blob);
+  http_request : (record {
+    url : text;
+    max_response_bytes: opt nat64;
+    method : variant { get; head; post };
+    headers: vec http_header;
+    body : opt blob;
+    transform : opt record {
+      function : func (record {response : http_response; context : blob}) -> (http_response) query;
+      context : blob
+    };
+  }) -> (http_response);
+
+  // Threshold ECDSA signature
+  ecdsa_public_key : (record {
+    canister_id : opt canister_id;
+    derivation_path : vec blob;
+    key_id : record { curve: ecdsa_curve; name: text };
+  }) -> (record { public_key : blob; chain_code : blob; });
+  sign_with_ecdsa : (record {
+    message_hash : blob;
+    derivation_path : vec blob;
+    key_id : record { curve: ecdsa_curve; name: text };
+  }) -> (record { signature : blob });
+
+  // bitcoin interface
+  bitcoin_get_balance: (get_balance_request) -> (satoshi);
+  bitcoin_get_balance_query: (get_balance_request) -> (satoshi) query;
+  bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
+  bitcoin_get_utxos_query: (get_utxos_request) -> (get_utxos_response) query;
+  bitcoin_send_transaction: (send_transaction_request) -> ();
+  bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+
+  // provisional interfaces for the pre-ledger world
+  provisional_create_canister_with_cycles : (record {
+    amount: opt nat;
+    settings : opt canister_settings;
+    specified_id: opt canister_id;
+    sender_canister_version : opt nat64;
+  }) -> (record {canister_id : canister_id});
+  provisional_top_up_canister :
+    (record { canister_id: canister_id; amount: nat }) -> ();
+}
+`;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -82,6 +82,7 @@ import {
     resolveVirtualPath,
 } from './utils';
 import { pascalCase } from 'change-case';
+import icCandid from '../candid/aaaaa-aa.did';
 
 const errorCodes: Record<
     string,
@@ -350,6 +351,12 @@ function notifyDfxChange() {
                     try {
                         const candidPath = join(projectDir, '.dfx/local/lsp');
                         const candidUri = URI.file(candidPath).toString();
+
+                        // Add management canister Candid file
+                        const icUri = URI.file(
+                            join(candidPath, 'aaaaa-aa.did'),
+                        ).toString();
+                        writeVirtual(resolveVirtualPath(icUri), icCandid);
 
                         const idsPath = join(
                             projectDir,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -380,7 +380,7 @@ function notifyDfxChange() {
                             Object.entries(pulledDeps.canisters).forEach(
                                 ([id, { name }]: [string, any]) => {
                                     aliases[name] = id;
-                                    // Add Candid as virtual file LSP directory
+                                    // Add Candid as virtual file in LSP directory
                                     const candid = readFileSync(
                                         join(
                                             projectDir,


### PR DESCRIPTION
This PR adds syntax highlighting for both `canister:` imports of `"type": "pull"` dependencies and `ic:aaaaa-aa` imports. 

Resolves #263.