### PR TITLE
Prioritize existing management canister Candid file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.15.1",
+    "version": "0.15.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.15.1",
+            "version": "0.15.2",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.15.1",
+    "version": "0.15.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -353,10 +353,11 @@ function notifyDfxChange() {
                         const candidUri = URI.file(candidPath).toString();
 
                         // Add management canister Candid file
-                        const icUri = URI.file(
-                            join(candidPath, 'aaaaa-aa.did'),
-                        ).toString();
-                        writeVirtual(resolveVirtualPath(icUri), icCandid);
+                        const icPath = join(candidPath, 'aaaaa-aa.did');
+                        if (!existsSync(icPath)) {
+                            const icUri = URI.file(icPath).toString();
+                            writeVirtual(resolveVirtualPath(icUri), icCandid);
+                        }
 
                         const idsPath = join(
                             projectDir,


### PR DESCRIPTION
Follow-up to #264. Gives priority to an existing `aaaaa-aa.did` file in the `.dfx/local/lsp` directory over the built-in default interface. 