### PR TITLE
Update canister URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Below are the default key bindings for commonly used features supported in the e
 ## Commands
 
 - `Motoko: Restart language server`: Starts (or restarts) the language server
-- `Motoko: Deploy (20 minutes)`: Temporarily deploys the currently open file to the Internet Computer via [Motoko Playground](https://m7sm4-2iaaa-aaaab-qabra-cai.raw.ic0.app/)
+- `Motoko: Deploy (20 minutes)`: Temporarily deploys the currently open file to the Internet Computer via [Motoko Playground](https://play.motoko.org/)
 - `Motoko: Import Mops Package...`: Search, install and import a package from [Mops](https://mops.one)
 
 [![Motoko Playground deployment](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/deploy.png)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,6 @@ import {
     tests,
     window,
     workspace,
-    Disposable,
 } from 'vscode';
 import {
     LanguageClient,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -434,7 +434,7 @@ async function deployPlayground(_context: ExtensionContext, uri: string) {
         }
         panel.webview.html = `
             <iframe
-                src="https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.ic0.app/?id=${
+                src="https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=${
                     result.canisterId
                 }&tag=${tag++}"
                 style="width:100vw; height:100vh; border:none"


### PR DESCRIPTION
Replaces `.ic0.app` with `.icp0.io` for Candid UI and uses the custom domain `play.motoko.org` for Motoko Playground. 