### PR TITLE
Suppress compiler warnings in `.mops` and `.vessel` directories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.16.0",
+            "version": "0.16.1",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -106,6 +106,9 @@ const ignoreGlobs = [
     '**/.vessel/.tmp/**/*', // temporary Vessel files
 ];
 
+const shouldHideWarnings = (uri: string) =>
+    uri.includes('/.vessel/') || uri.includes('/.mops/');
+
 const packageSourceCache = new Map();
 async function getPackageSources(
     directory: string,
@@ -866,11 +869,7 @@ function checkImmediate(uri: string | TextDocument): boolean {
                         !new RegExp(settings!.hideWarningRegex).test(message),
                 );
             }
-            if (
-                resolvedUri &&
-                (resolvedUri.includes('/.vessel/') ||
-                    resolvedUri.includes('/.mops/'))
-            ) {
+            if (resolvedUri && shouldHideWarnings(resolvedUri)) {
                 diagnostics = diagnostics.filter(
                     ({ severity }) => severity === DiagnosticSeverity.Error,
                 );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -866,6 +866,15 @@ function checkImmediate(uri: string | TextDocument): boolean {
                         !new RegExp(settings!.hideWarningRegex).test(message),
                 );
             }
+            if (
+                resolvedUri &&
+                (resolvedUri.includes('/.vessel/') ||
+                    resolvedUri.includes('/.mops/'))
+            ) {
+                diagnostics = diagnostics.filter(
+                    ({ severity }) => severity === DiagnosticSeverity.Error,
+                );
+            }
         }
         const diagnosticMap: Record<string, Diagnostic[]> = {
             [virtualPath]: [], // Start with empty diagnostics for the main file


### PR DESCRIPTION
Removes warnings in downloaded package dependencies while continuing to show compiler errors.