### PR TITLE
Bump `ic-mops` to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "change-case": "4.1.2",
                 "execa": "^4.1.0",
                 "fast-glob": "3.2.12",
-                "ic-mops": "0.26.3",
+                "ic-mops": "0.39.2",
                 "ic0": "0.2.7",
                 "mnemonist": "0.39.5",
                 "motoko": "3.6.14",
@@ -646,44 +646,48 @@
             }
         },
         "node_modules/@dfinity/identity-secp256k1": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.18.1.tgz",
-            "integrity": "sha512-3yaXQ2awLJAprarMjhtv8XtXMV8+AfqF6Q6Et0K3qMzIwgff31WQrl/98ZzP5QLs0vfeT1Q8yJT2OFuhwgL2nA==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.19.3.tgz",
+            "integrity": "sha512-mllF0y1p5zmZo24vqCSXTHAT89z4p0e90/23BjMlyWLjVlpZ4YSXThWILKg/z4e0cbiLpadScOPIy5scbaC90g==",
             "dependencies": {
-                "@dfinity/agent": "^0.18.1",
+                "@dfinity/agent": "^0.19.3",
+                "@noble/hashes": "^1.3.1",
                 "bip39": "^3.0.4",
                 "bs58check": "^2.1.2",
                 "secp256k1": "^4.0.3"
             }
         },
         "node_modules/@dfinity/identity-secp256k1/node_modules/@dfinity/agent": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-            "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.3.tgz",
+            "integrity": "sha512-q410aNLoOA1ZkwdAMgSo6t++pjISn9TfSybRXhPRI5Ume7eG6+6qYr/rlvcXy7Nb2+Ar7LTsHNn34IULfjni7w==",
             "dependencies": {
+                "@noble/hashes": "^1.3.1",
                 "base64-arraybuffer": "^0.2.0",
                 "borc": "^2.1.1",
-                "js-sha256": "0.9.0",
                 "simple-cbor": "^0.4.1"
             },
             "peerDependencies": {
-                "@dfinity/candid": "^0.18.1",
-                "@dfinity/principal": "^0.18.1"
+                "@dfinity/candid": "^0.19.3",
+                "@dfinity/principal": "^0.19.3"
             }
         },
         "node_modules/@dfinity/identity-secp256k1/node_modules/@dfinity/candid": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-            "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg==",
-            "peer": true
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.3.tgz",
+            "integrity": "sha512-yXfbLSWTeRd4G0bLLxYoDqpXH3Jim0P+1PPZOoktXNC1X1hB+ea3yrZebX75t4GVoQK7123F7mxWHiPjuV2tQQ==",
+            "peer": true,
+            "peerDependencies": {
+                "@dfinity/principal": "^0.19.3"
+            }
         },
         "node_modules/@dfinity/identity-secp256k1/node_modules/@dfinity/principal": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-            "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.3.tgz",
+            "integrity": "sha512-+nixVvdGt7ECxRvLXDXsvU9q9sSPssBtDQ4bXa149SK6gcYcmZ6lfWIi3DJNqj3tGROxILVBsguel9tECappsA==",
             "peer": true,
             "dependencies": {
-                "js-sha256": "^0.9.0"
+                "@noble/hashes": "^1.3.1"
             }
         },
         "node_modules/@dfinity/principal": {
@@ -1633,6 +1637,224 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/lzma": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.2.1.tgz",
+            "integrity": "sha512-vwl34tzF2mXWthnFVN2MP6nRzQ40C5+256EEUjxAwj9dbAhDqb7Yz376Up5SlB4YgNC0YvEqK4jsYP/NP0bgpg==",
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@napi-rs/lzma-android-arm-eabi": "1.2.1",
+                "@napi-rs/lzma-android-arm64": "1.2.1",
+                "@napi-rs/lzma-darwin-arm64": "1.2.1",
+                "@napi-rs/lzma-darwin-x64": "1.2.1",
+                "@napi-rs/lzma-freebsd-x64": "1.2.1",
+                "@napi-rs/lzma-linux-arm-gnueabihf": "1.2.1",
+                "@napi-rs/lzma-linux-arm64-gnu": "1.2.1",
+                "@napi-rs/lzma-linux-arm64-musl": "1.2.1",
+                "@napi-rs/lzma-linux-x64-gnu": "1.2.1",
+                "@napi-rs/lzma-linux-x64-musl": "1.2.1",
+                "@napi-rs/lzma-win32-arm64-msvc": "1.2.1",
+                "@napi-rs/lzma-win32-ia32-msvc": "1.2.1",
+                "@napi-rs/lzma-win32-x64-msvc": "1.2.1"
+            }
+        },
+        "node_modules/@napi-rs/lzma-android-arm-eabi": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.2.1.tgz",
+            "integrity": "sha512-GKXud2hTddxehff1mAGkbTfseBj+GcM+M/sZuxf9H9CJeOWpfI/HC9Oy3uv8mBqPTkOQdCcZ/xXPU34EOEwiRg==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-android-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.2.1.tgz",
+            "integrity": "sha512-UKFvc56TdgljbdgLvSwM62pSItV/4SuXXCrJtruPDmbIDe8HKag8hsCKsb66hrc9aX7urJ+KGw1yz5hWiONLyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-darwin-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.2.1.tgz",
+            "integrity": "sha512-eLbHzK5xGVzEABb1ESFELQJzXKoQeP9QH9hMPd4Qq29xD6MkWD2VKlAy40AxrMeWc7fCUIImTTlGuGRvg6tI1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-darwin-x64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.2.1.tgz",
+            "integrity": "sha512-/a5sHZkkO81w/PCpxlwXjADz++jDiTJquMzCLAhupd23wTRmJoCBAwp4Tur+qV5esI7ahAA0lS5P0M4TZv+OUg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-freebsd-x64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.2.1.tgz",
+            "integrity": "sha512-Ehc0ld148YcqQrDWwUbVta1l45R4PthCIU6ZDbOYzzeYXQnhgr1fWiex7wu4KMFppteHlYntypUIhmMUklqchA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-arm-gnueabihf": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.2.1.tgz",
+            "integrity": "sha512-EkIsx3kC67viElNetZgaGAtAceA+4pVGj31HKKPn0RZYn3rCNdEEg2i1IRg07Y6m4bHwcaKutLoZ2LDcQ+yiBg==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-arm64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.2.1.tgz",
+            "integrity": "sha512-GxSbp1/X7Ppmf+aNiZ95vl1HgQzRS9C8zCv7unEhYRPAjRkAnlrsLluUBOTPIY2yquuUvfIog9XIml6Hpw2wrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-arm64-musl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.2.1.tgz",
+            "integrity": "sha512-2L3KHFGGdt0xgU0WcKwKmnjVCYs88t4+ixBgPfEydtYsOceg6B8eOzdM7xsziKxJyUJKWBetGLgARQOy35bfvA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.2.1.tgz",
+            "integrity": "sha512-h29XttA2Og1+6vYHsVcp+i1PkeILKzYnoDun0ul/k/5hvfxJ2Jap+EM07sW4HSz/DiscLAeIZmLKbXEqJgF5bg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-x64-musl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.2.1.tgz",
+            "integrity": "sha512-8EIkpLid4pepkBsljQ7rgma8jdwAuwVyJ2tY6Wuj1I/AqAkVVfxTwIuYc4zgRR3nfcrmWgOfZE0VneVmQCE5hw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-win32-arm64-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.2.1.tgz",
+            "integrity": "sha512-RNPItarWUUbtwz6dyn8FGH9AXEaAsBcMBlTvcRjv8eoqRqyZ9R49Ruk/8WMS57MM1BKdiPDxHBtRi+nZn27Slw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-win32-ia32-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.2.1.tgz",
+            "integrity": "sha512-rNdsCZnzKVgeDd9NzXWk9WuADVUWUWdnws8qBRCfHRUQqJ56Ic1W7Y1XmP+bNa985MXlU6vbznHTHmU5zk2P+A==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/lzma-win32-x64-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.2.1.tgz",
+            "integrity": "sha512-1AFrAh1n73Yw+IhDu5HnaiRD4vWEkafY0EarfziPfDsh/GeyNcjbE+Let+XFe8L3j0/CZfsRG3nXarOW1oadUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@noble/hashes": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
@@ -1675,6 +1897,337 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@octokit/app": {
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
+            "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
+            "dependencies": {
+                "@octokit/auth-app": "^6.0.0",
+                "@octokit/auth-unauthenticated": "^5.0.0",
+                "@octokit/core": "^5.0.0",
+                "@octokit/oauth-app": "^6.0.0",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/types": "^12.0.0",
+                "@octokit/webhooks": "^12.0.4"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/auth-app": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.0.4.tgz",
+            "integrity": "sha512-TPmJYgd05ok3nzHj7Y6we/V7Ez1wU3ztLFW3zo/afgYFtqYZg0W7zb6Kp5ag6E85r8nCE1JfS6YZoZusa14o9g==",
+            "dependencies": {
+                "@octokit/auth-oauth-app": "^7.0.0",
+                "@octokit/auth-oauth-user": "^4.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "deprecation": "^2.3.1",
+                "lru-cache": "^10.0.0",
+                "universal-github-app-jwt": "^1.1.2",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/auth-app/node_modules/lru-cache": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/@octokit/auth-oauth-app": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.0.1.tgz",
+            "integrity": "sha512-RE0KK0DCjCHXHlQBoubwlLijXEKfhMhKm9gO56xYvFmP1QTMb+vvwRPmQLLx0V+5AvV9N9I3lr1WyTzwL3rMDg==",
+            "dependencies": {
+                "@octokit/auth-oauth-device": "^6.0.0",
+                "@octokit/auth-oauth-user": "^4.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/types": "^12.0.0",
+                "@types/btoa-lite": "^1.0.0",
+                "btoa-lite": "^1.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/auth-oauth-device": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.0.1.tgz",
+            "integrity": "sha512-yxU0rkL65QkjbqQedgVx3gmW7YM5fF+r5uaSj9tM/cQGVqloXcqP2xK90eTyYvl29arFVCW8Vz4H/t47mL0ELw==",
+            "dependencies": {
+                "@octokit/oauth-methods": "^4.0.0",
+                "@octokit/request": "^8.0.0",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/auth-oauth-user": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.0.1.tgz",
+            "integrity": "sha512-N94wWW09d0hleCnrO5wt5MxekatqEJ4zf+1vSe8MKMrhZ7gAXKFOKrDEZW2INltvBWJCyDUELgGRv8gfErH1Iw==",
+            "dependencies": {
+                "@octokit/auth-oauth-device": "^6.0.0",
+                "@octokit/oauth-methods": "^4.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/types": "^12.0.0",
+                "btoa-lite": "^1.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/auth-unauthenticated": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+            "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+            "dependencies": {
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
+            "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
+            "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+            "dependencies": {
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+            "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+            "dependencies": {
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/oauth-app": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+            "integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+            "dependencies": {
+                "@octokit/auth-oauth-app": "^7.0.0",
+                "@octokit/auth-oauth-user": "^4.0.0",
+                "@octokit/auth-unauthenticated": "^5.0.0",
+                "@octokit/core": "^5.0.0",
+                "@octokit/oauth-authorization-url": "^6.0.2",
+                "@octokit/oauth-methods": "^4.0.0",
+                "@types/aws-lambda": "^8.10.83",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/oauth-authorization-url": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+            "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/oauth-methods": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.0.1.tgz",
+            "integrity": "sha512-1NdTGCoBHyD6J0n2WGXg9+yDLZrRNZ0moTEex/LSPr49m530WNKcCfXDghofYptr3st3eTii+EHoG5k/o+vbtw==",
+            "dependencies": {
+                "@octokit/oauth-authorization-url": "^6.0.2",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "btoa-lite": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+        },
+        "node_modules/@octokit/plugin-paginate-graphql": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+            "integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=5"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+            "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-retry": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+            "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
+            "dependencies": {
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "bottleneck": "^2.15.3"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=5"
+            }
+        },
+        "node_modules/@octokit/plugin-throttling": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+            "integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+            "dependencies": {
+                "@octokit/types": "^12.2.0",
+                "bottleneck": "^2.15.3"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "^5.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
+            "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+            "dependencies": {
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
+            "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+            "dependencies": {
+                "@octokit/types": "^12.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/webhooks": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.1.2.tgz",
+            "integrity": "sha512-+nGS3ReCByF6m+nbNB59x7Aa3CNjCCGuBLFzfkiJP1O3uVKKuJbkP4uO4t46YqH26nlugmOhqjT7nx5D0VPtdA==",
+            "dependencies": {
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/webhooks-methods": "^4.1.0",
+                "@octokit/webhooks-types": "7.3.2",
+                "aggregate-error": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/webhooks-methods": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+            "integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/webhooks-types": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.3.2.tgz",
+            "integrity": "sha512-JWOoOgtWTFnTSAamPXXyjTY5/apttvNxF+vPBnwdSu5cj5snrd7FO0fyw4+wTXy8fHduq626JjhO+TwCyyA6vA=="
         },
         "node_modules/@peculiar/asn1-schema": {
             "version": "2.3.6",
@@ -1790,6 +2343,11 @@
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
             "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
         },
+        "node_modules/@types/aws-lambda": {
+            "version": "8.10.136",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.136.tgz",
+            "integrity": "sha512-cmmgqxdVGhxYK9lZMYYXYRJk6twBo53ivtXjIUEFZxfxe4TkZTZBK3RRWrY2HjJcUIix0mdifn15yjOAat5lTA=="
+        },
         "node_modules/@types/babel__core": {
             "version": "7.1.19",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -1829,6 +2387,19 @@
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.3.0"
+            }
+        },
+        "node_modules/@types/btoa-lite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+            "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+            "dependencies": {
+                "@types/ms": "*"
             }
         },
         "node_modules/@types/graceful-fs": {
@@ -1885,6 +2456,27 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
+        "node_modules/@types/jsonwebtoken": {
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+            "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/mdast": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+            "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/ms": {
+            "version": "0.7.34",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+            "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+        },
         "node_modules/@types/node": {
             "version": "14.14.30",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
@@ -1907,6 +2499,11 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+            "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
         },
         "node_modules/@types/vscode": {
             "version": "1.71.0",
@@ -2225,7 +2822,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
             "dependencies": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -2360,6 +2956,11 @@
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
             }
+        },
+        "node_modules/b4a": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
         },
         "node_modules/babel-jest": {
             "version": "29.1.2",
@@ -2527,6 +3128,12 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
+        "node_modules/bare-events": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.1.tgz",
+            "integrity": "sha512-9GYPpsPFvrWBkelIhOhTWtkeZxVxZOdb3VnFTCzlOo3OjvmTvzLoZFUT8kNFACx0vJej6QPney1Cf9BvzCNE/A==",
+            "optional": true
+        },
         "node_modules/base-x": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -2561,6 +3168,11 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "node_modules/bignumber.js": {
             "version": "9.1.1",
@@ -2629,6 +3241,11 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -2722,6 +3339,11 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "node_modules/btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
+        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2766,6 +3388,11 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "node_modules/buffer-fill": {
             "version": "1.0.0",
@@ -2921,6 +3548,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/cheerio": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -3016,7 +3652,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3320,6 +3955,97 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+            "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/decomp-tar": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/decomp-tar/-/decomp-tar-0.1.1.tgz",
+            "integrity": "sha512-+MVkfgK6GRAdwbIN/4LTpBjONYCeCvAHWyQNYZXjl1e3bPKbNHu+dL62qR5ziHcMhjCeFOGvMx1mZbfiQ6+4zg==",
+            "dependencies": {
+                "file-type": "^5.2.0",
+                "is-stream": "^3.0.0",
+                "tar-stream": "^3.1.6"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decomp-tar/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decomp-tar/node_modules/tar-stream": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/decomp-tarxz": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/decomp-tarxz/-/decomp-tarxz-0.1.1.tgz",
+            "integrity": "sha512-V6bThFjjouy/kQz6cDuf/DZnQ5eMi32bggu6rSNByNnzTll7jDygUWFDV2J3x6LUZVU4CsfpkNFHcUeGgl/SUQ==",
+            "dependencies": {
+                "@napi-rs/lzma": "^1.1.2",
+                "decomp-tar": "^0.1.1",
+                "file-type": "^12.3.0",
+                "get-stream": "^8.0.1",
+                "is-stream": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/decomp-tarxz/node_modules/file-type": {
+            "version": "12.4.2",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+            "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/decomp-tarxz/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decomp-tarxz/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/decompress": {
@@ -3748,6 +4474,19 @@
             "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
             "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
         },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -3764,6 +4503,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "dependencies": {
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/dhall-to-json-cli": {
@@ -3892,6 +4643,14 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.4.271",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.271.tgz",
@@ -3899,9 +4658,9 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -4505,6 +5264,11 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+        },
         "node_modules/fast-glob": {
             "version": "3.2.12",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -4687,6 +5451,19 @@
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
+        "node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/fs-minipass": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -4781,6 +5558,17 @@
             "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-folder-size": {
@@ -5134,100 +5922,114 @@
             }
         },
         "node_modules/ic-mops": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-0.26.3.tgz",
-            "integrity": "sha512-AQSIpU9C16IdW+0v+fN0KD5eZxjVq7oMXWYet63vwLA+v42i49Uy0sH4b1DbVPreZouGwoZmbKbBaU0feiRBnA==",
+            "version": "0.39.2",
+            "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-0.39.2.tgz",
+            "integrity": "sha512-OIwP5Zl0v2VgaUte9inrVDUL0T53SUOxpE5WEj8+RTI40MG/zGb0vrgIcNVjZM6hsmynPtfAd/O1OMaoFuz2pg==",
             "dependencies": {
-                "@dfinity/agent": "^0.18.1",
-                "@dfinity/candid": "^0.18.1",
-                "@dfinity/identity": "^0.18.1",
-                "@dfinity/identity-secp256k1": "^0.18.1",
-                "@dfinity/principal": "^0.18.1",
+                "@dfinity/agent": "^0.19.3",
+                "@dfinity/candid": "^0.19.3",
+                "@dfinity/identity": "^0.19.3",
+                "@dfinity/identity-secp256k1": "^0.19.3",
+                "@dfinity/principal": "^0.19.3",
                 "@iarna/toml": "^2.2.5",
+                "@noble/hashes": "1.3.2",
                 "as-table": "^1.0.55",
                 "cacheable-request": "10.2.12",
                 "camelcase": "^7.0.1",
                 "chalk": "^5.3.0",
                 "chokidar": "^3.5.3",
-                "commander": "^11.0.0",
+                "commander": "11.1.0",
                 "debounce": "^1.2.1",
+                "decomp-tarxz": "0.1.1",
                 "decompress": "^4.2.1",
                 "del": "^7.0.0",
                 "dhall-to-json-cli": "^1.7.6",
                 "eslint": "^8.45.0",
                 "execa": "7.1.1",
+                "fs-extra": "11.2.0",
                 "get-folder-size": "^4.0.0",
                 "glob": "^10.3.3",
                 "globby": "^13.2.2",
                 "got": "13.0.0",
-                "log-update": "^5.0.1",
+                "log-update": "6.0.0",
+                "markdown-table": "3.0.3",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.1.0",
                 "minimatch": "^9.0.3",
                 "ncp": "^2.0.0",
                 "node-fetch": "^3.3.2",
+                "octokit": "3.1.2",
                 "pem-file": "^1.0.1",
+                "pic-ic": "0.3.2",
                 "prompts": "^2.4.2",
                 "stream-to-promise": "^3.0.0",
+                "string-width": "7.0.0",
                 "tar": "^6.1.15"
             },
             "bin": {
-                "mops": "dist/cli.js"
+                "ic-mops": "dist/bin/mops.js",
+                "moc-wrapper": "bin/moc-wrapper.sh",
+                "mops": "dist/bin/mops.js"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/ic-mops/node_modules/@dfinity/agent": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-            "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.3.tgz",
+            "integrity": "sha512-q410aNLoOA1ZkwdAMgSo6t++pjISn9TfSybRXhPRI5Ume7eG6+6qYr/rlvcXy7Nb2+Ar7LTsHNn34IULfjni7w==",
             "dependencies": {
+                "@noble/hashes": "^1.3.1",
                 "base64-arraybuffer": "^0.2.0",
                 "borc": "^2.1.1",
-                "js-sha256": "0.9.0",
                 "simple-cbor": "^0.4.1"
             },
             "peerDependencies": {
-                "@dfinity/candid": "^0.18.1",
-                "@dfinity/principal": "^0.18.1"
+                "@dfinity/candid": "^0.19.3",
+                "@dfinity/principal": "^0.19.3"
             }
         },
         "node_modules/ic-mops/node_modules/@dfinity/candid": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-            "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg=="
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.3.tgz",
+            "integrity": "sha512-yXfbLSWTeRd4G0bLLxYoDqpXH3Jim0P+1PPZOoktXNC1X1hB+ea3yrZebX75t4GVoQK7123F7mxWHiPjuV2tQQ==",
+            "peerDependencies": {
+                "@dfinity/principal": "^0.19.3"
+            }
         },
         "node_modules/ic-mops/node_modules/@dfinity/identity": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.18.1.tgz",
-            "integrity": "sha512-u8pXzjEciaLad8WykwIO4nuASr0MdJHwFjd32TKr6oquJ6caMCDj0N8vlHfoWM6oInhYIWIME4pucjAM/isP2A==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.3.tgz",
+            "integrity": "sha512-6XHrkNQ8tVN6+MERyXPy+avGHTd2zoX3l47bu6gSwreDdOZQnAnXpHVzLcXhnUptkBVetcC70YQEKCmqtuLriA==",
             "dependencies": {
+                "@noble/hashes": "^1.3.1",
                 "borc": "^2.1.1",
-                "js-sha256": "^0.9.0",
                 "tweetnacl": "^1.0.1"
             },
             "peerDependencies": {
-                "@dfinity/agent": "^0.18.1",
-                "@dfinity/principal": "^0.18.1",
+                "@dfinity/agent": "^0.19.3",
+                "@dfinity/principal": "^0.19.3",
                 "@peculiar/webcrypto": "^1.4.0"
             }
         },
         "node_modules/ic-mops/node_modules/@dfinity/principal": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-            "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.3.tgz",
+            "integrity": "sha512-+nixVvdGt7ECxRvLXDXsvU9q9sSPssBtDQ4bXa149SK6gcYcmZ6lfWIi3DJNqj3tGROxILVBsguel9tECappsA==",
             "dependencies": {
-                "js-sha256": "^0.9.0"
+                "@noble/hashes": "^1.3.1"
             }
         },
         "node_modules/ic-mops/node_modules/ansi-escapes": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-            "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
+            "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
             "dependencies": {
-                "type-fest": "^1.0.2"
+                "type-fest": "^3.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5300,17 +6102,17 @@
             }
         },
         "node_modules/ic-mops/node_modules/commander": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/ic-mops/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+            "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
         },
         "node_modules/ic-mops/node_modules/execa": {
             "version": "7.1.1",
@@ -5396,6 +6198,20 @@
                 "node": ">=14.18.0"
             }
         },
+        "node_modules/ic-mops/node_modules/is-fullwidth-code-point": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+            "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+            "dependencies": {
+                "get-east-asian-width": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ic-mops/node_modules/is-stream": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -5408,18 +6224,18 @@
             }
         },
         "node_modules/ic-mops/node_modules/log-update": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-            "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
+            "integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
             "dependencies": {
-                "ansi-escapes": "^5.0.0",
+                "ansi-escapes": "^6.2.0",
                 "cli-cursor": "^4.0.0",
-                "slice-ansi": "^5.0.0",
-                "strip-ansi": "^7.0.1",
-                "wrap-ansi": "^8.0.1"
+                "slice-ansi": "^7.0.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5489,6 +6305,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/ic-mops/node_modules/pic-ic": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/pic-ic/-/pic-ic-0.3.2.tgz",
+            "integrity": "sha512-4gCfsyzdiMzn/j9R73MjWIdvRJbRf+aRy+Gym/HGKJGX6hM69iI11EpHRj76Ot5io1xGlAGAZjXK6PA/7MEaKw==",
+            "dependencies": {
+                "bip39": "^3.1.0"
+            },
+            "peerDependencies": {
+                "@dfinity/agent": "^0.19.3",
+                "@dfinity/candid": "^0.19.3",
+                "@dfinity/identity": "^0.19.3",
+                "@dfinity/principal": "^0.19.3"
+            }
+        },
         "node_modules/ic-mops/node_modules/restore-cursor": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -5537,17 +6367,32 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ic-mops/node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+        "node_modules/ic-mops/node_modules/slice-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+            "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/ic-mops/node_modules/string-width": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz",
+            "integrity": "sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5579,27 +6424,27 @@
             }
         },
         "node_modules/ic-mops/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+            "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ic-mops/node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+            "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -5698,7 +6543,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7849,6 +8693,71 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonwebtoken": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "dependencies": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/semver": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/keytar": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -8212,6 +9121,36 @@
                 "node": ">=8"
             }
         },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8222,6 +9161,11 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
         },
         "node_modules/log-update": {
             "version": "4.0.0",
@@ -8303,6 +9247,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/lower-case": {
@@ -8398,6 +9351,15 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/markdown-table": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8406,6 +9368,73 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+            "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+            "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/mdurl": {
@@ -8435,6 +9464,427 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/micromark": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+            "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+            "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+            "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+            "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+            "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+            "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+            "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+            "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+            "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+            "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+            "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+            "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+            "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+            "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+            "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
+        },
+        "node_modules/micromark-util-types": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
         },
         "node_modules/micromatch": {
             "version": "4.0.5",
@@ -8696,9 +10146,9 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+            "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -8908,6 +10358,26 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
             "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+        },
+        "node_modules/octokit": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+            "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+            "dependencies": {
+                "@octokit/app": "^14.0.2",
+                "@octokit/core": "^5.0.0",
+                "@octokit/oauth-app": "^6.0.0",
+                "@octokit/plugin-paginate-graphql": "^4.0.0",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+                "@octokit/plugin-retry": "^6.0.0",
+                "@octokit/plugin-throttling": "^8.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -9465,6 +10935,11 @@
                 }
             ]
         },
+        "node_modules/queue-tick": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+        },
         "node_modules/quick-lru": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -10007,6 +11482,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
             "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^6.0.0",
                 "is-fullwidth-code-point": "^4.0.0"
@@ -10022,6 +11498,7 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -10033,6 +11510,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
             "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -10146,6 +11624,18 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/streamx": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
+            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+            "dependencies": {
+                "fast-fifo": "^1.1.0",
+                "queue-tick": "^1.0.1"
+            },
+            "optionalDependencies": {
+                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {
@@ -10756,6 +12246,79 @@
             "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
             "dev": true
         },
+        "node_modules/unist-util-is": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+            "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-stringify-position": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+            "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit-parents": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+            "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/universal-github-app-jwt": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.2.tgz",
+            "integrity": "sha512-t1iB2FmLFE+yyJY9+3wMx0ejB+MQpEVkH0gQv7dR6FZyltyq+ZZO0uDpbopxhrZ3SLEO4dCEkIujOMldEQ2iOA==",
+            "dependencies": {
+                "@types/jsonwebtoken": "^9.0.0",
+                "jsonwebtoken": "^9.0.2"
+            }
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
@@ -11292,6 +12855,15 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zwitch": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         }
     },
     "dependencies": {
@@ -11745,40 +13317,42 @@
             }
         },
         "@dfinity/identity-secp256k1": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.18.1.tgz",
-            "integrity": "sha512-3yaXQ2awLJAprarMjhtv8XtXMV8+AfqF6Q6Et0K3qMzIwgff31WQrl/98ZzP5QLs0vfeT1Q8yJT2OFuhwgL2nA==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.19.3.tgz",
+            "integrity": "sha512-mllF0y1p5zmZo24vqCSXTHAT89z4p0e90/23BjMlyWLjVlpZ4YSXThWILKg/z4e0cbiLpadScOPIy5scbaC90g==",
             "requires": {
-                "@dfinity/agent": "^0.18.1",
+                "@dfinity/agent": "^0.19.3",
+                "@noble/hashes": "^1.3.1",
                 "bip39": "^3.0.4",
                 "bs58check": "^2.1.2",
                 "secp256k1": "^4.0.3"
             },
             "dependencies": {
                 "@dfinity/agent": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-                    "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.3.tgz",
+                    "integrity": "sha512-q410aNLoOA1ZkwdAMgSo6t++pjISn9TfSybRXhPRI5Ume7eG6+6qYr/rlvcXy7Nb2+Ar7LTsHNn34IULfjni7w==",
                     "requires": {
+                        "@noble/hashes": "^1.3.1",
                         "base64-arraybuffer": "^0.2.0",
                         "borc": "^2.1.1",
-                        "js-sha256": "0.9.0",
                         "simple-cbor": "^0.4.1"
                     }
                 },
                 "@dfinity/candid": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-                    "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg==",
-                    "peer": true
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.3.tgz",
+                    "integrity": "sha512-yXfbLSWTeRd4G0bLLxYoDqpXH3Jim0P+1PPZOoktXNC1X1hB+ea3yrZebX75t4GVoQK7123F7mxWHiPjuV2tQQ==",
+                    "peer": true,
+                    "requires": {}
                 },
                 "@dfinity/principal": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-                    "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.3.tgz",
+                    "integrity": "sha512-+nixVvdGt7ECxRvLXDXsvU9q9sSPssBtDQ4bXa149SK6gcYcmZ6lfWIi3DJNqj3tGROxILVBsguel9tECappsA==",
                     "peer": true,
                     "requires": {
-                        "js-sha256": "^0.9.0"
+                        "@noble/hashes": "^1.3.1"
                     }
                 }
             }
@@ -12475,6 +14049,104 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "@napi-rs/lzma": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.2.1.tgz",
+            "integrity": "sha512-vwl34tzF2mXWthnFVN2MP6nRzQ40C5+256EEUjxAwj9dbAhDqb7Yz376Up5SlB4YgNC0YvEqK4jsYP/NP0bgpg==",
+            "requires": {
+                "@napi-rs/lzma-android-arm-eabi": "1.2.1",
+                "@napi-rs/lzma-android-arm64": "1.2.1",
+                "@napi-rs/lzma-darwin-arm64": "1.2.1",
+                "@napi-rs/lzma-darwin-x64": "1.2.1",
+                "@napi-rs/lzma-freebsd-x64": "1.2.1",
+                "@napi-rs/lzma-linux-arm-gnueabihf": "1.2.1",
+                "@napi-rs/lzma-linux-arm64-gnu": "1.2.1",
+                "@napi-rs/lzma-linux-arm64-musl": "1.2.1",
+                "@napi-rs/lzma-linux-x64-gnu": "1.2.1",
+                "@napi-rs/lzma-linux-x64-musl": "1.2.1",
+                "@napi-rs/lzma-win32-arm64-msvc": "1.2.1",
+                "@napi-rs/lzma-win32-ia32-msvc": "1.2.1",
+                "@napi-rs/lzma-win32-x64-msvc": "1.2.1"
+            }
+        },
+        "@napi-rs/lzma-android-arm-eabi": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.2.1.tgz",
+            "integrity": "sha512-GKXud2hTddxehff1mAGkbTfseBj+GcM+M/sZuxf9H9CJeOWpfI/HC9Oy3uv8mBqPTkOQdCcZ/xXPU34EOEwiRg==",
+            "optional": true
+        },
+        "@napi-rs/lzma-android-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.2.1.tgz",
+            "integrity": "sha512-UKFvc56TdgljbdgLvSwM62pSItV/4SuXXCrJtruPDmbIDe8HKag8hsCKsb66hrc9aX7urJ+KGw1yz5hWiONLyw==",
+            "optional": true
+        },
+        "@napi-rs/lzma-darwin-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.2.1.tgz",
+            "integrity": "sha512-eLbHzK5xGVzEABb1ESFELQJzXKoQeP9QH9hMPd4Qq29xD6MkWD2VKlAy40AxrMeWc7fCUIImTTlGuGRvg6tI1g==",
+            "optional": true
+        },
+        "@napi-rs/lzma-darwin-x64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.2.1.tgz",
+            "integrity": "sha512-/a5sHZkkO81w/PCpxlwXjADz++jDiTJquMzCLAhupd23wTRmJoCBAwp4Tur+qV5esI7ahAA0lS5P0M4TZv+OUg==",
+            "optional": true
+        },
+        "@napi-rs/lzma-freebsd-x64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.2.1.tgz",
+            "integrity": "sha512-Ehc0ld148YcqQrDWwUbVta1l45R4PthCIU6ZDbOYzzeYXQnhgr1fWiex7wu4KMFppteHlYntypUIhmMUklqchA==",
+            "optional": true
+        },
+        "@napi-rs/lzma-linux-arm-gnueabihf": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.2.1.tgz",
+            "integrity": "sha512-EkIsx3kC67viElNetZgaGAtAceA+4pVGj31HKKPn0RZYn3rCNdEEg2i1IRg07Y6m4bHwcaKutLoZ2LDcQ+yiBg==",
+            "optional": true
+        },
+        "@napi-rs/lzma-linux-arm64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.2.1.tgz",
+            "integrity": "sha512-GxSbp1/X7Ppmf+aNiZ95vl1HgQzRS9C8zCv7unEhYRPAjRkAnlrsLluUBOTPIY2yquuUvfIog9XIml6Hpw2wrA==",
+            "optional": true
+        },
+        "@napi-rs/lzma-linux-arm64-musl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.2.1.tgz",
+            "integrity": "sha512-2L3KHFGGdt0xgU0WcKwKmnjVCYs88t4+ixBgPfEydtYsOceg6B8eOzdM7xsziKxJyUJKWBetGLgARQOy35bfvA==",
+            "optional": true
+        },
+        "@napi-rs/lzma-linux-x64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.2.1.tgz",
+            "integrity": "sha512-h29XttA2Og1+6vYHsVcp+i1PkeILKzYnoDun0ul/k/5hvfxJ2Jap+EM07sW4HSz/DiscLAeIZmLKbXEqJgF5bg==",
+            "optional": true
+        },
+        "@napi-rs/lzma-linux-x64-musl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.2.1.tgz",
+            "integrity": "sha512-8EIkpLid4pepkBsljQ7rgma8jdwAuwVyJ2tY6Wuj1I/AqAkVVfxTwIuYc4zgRR3nfcrmWgOfZE0VneVmQCE5hw==",
+            "optional": true
+        },
+        "@napi-rs/lzma-win32-arm64-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.2.1.tgz",
+            "integrity": "sha512-RNPItarWUUbtwz6dyn8FGH9AXEaAsBcMBlTvcRjv8eoqRqyZ9R49Ruk/8WMS57MM1BKdiPDxHBtRi+nZn27Slw==",
+            "optional": true
+        },
+        "@napi-rs/lzma-win32-ia32-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.2.1.tgz",
+            "integrity": "sha512-rNdsCZnzKVgeDd9NzXWk9WuADVUWUWdnws8qBRCfHRUQqJ56Ic1W7Y1XmP+bNa985MXlU6vbznHTHmU5zk2P+A==",
+            "optional": true
+        },
+        "@napi-rs/lzma-win32-x64-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.2.1.tgz",
+            "integrity": "sha512-1AFrAh1n73Yw+IhDu5HnaiRD4vWEkafY0EarfziPfDsh/GeyNcjbE+Let+XFe8L3j0/CZfsRG3nXarOW1oadUQ==",
+            "optional": true
+        },
         "@noble/hashes": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
@@ -12502,6 +14174,256 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@octokit/app": {
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
+            "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
+            "requires": {
+                "@octokit/auth-app": "^6.0.0",
+                "@octokit/auth-unauthenticated": "^5.0.0",
+                "@octokit/core": "^5.0.0",
+                "@octokit/oauth-app": "^6.0.0",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/types": "^12.0.0",
+                "@octokit/webhooks": "^12.0.4"
+            }
+        },
+        "@octokit/auth-app": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.0.4.tgz",
+            "integrity": "sha512-TPmJYgd05ok3nzHj7Y6we/V7Ez1wU3ztLFW3zo/afgYFtqYZg0W7zb6Kp5ag6E85r8nCE1JfS6YZoZusa14o9g==",
+            "requires": {
+                "@octokit/auth-oauth-app": "^7.0.0",
+                "@octokit/auth-oauth-user": "^4.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "deprecation": "^2.3.1",
+                "lru-cache": "^10.0.0",
+                "universal-github-app-jwt": "^1.1.2",
+                "universal-user-agent": "^6.0.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "10.2.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+                    "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q=="
+                }
+            }
+        },
+        "@octokit/auth-oauth-app": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.0.1.tgz",
+            "integrity": "sha512-RE0KK0DCjCHXHlQBoubwlLijXEKfhMhKm9gO56xYvFmP1QTMb+vvwRPmQLLx0V+5AvV9N9I3lr1WyTzwL3rMDg==",
+            "requires": {
+                "@octokit/auth-oauth-device": "^6.0.0",
+                "@octokit/auth-oauth-user": "^4.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/types": "^12.0.0",
+                "@types/btoa-lite": "^1.0.0",
+                "btoa-lite": "^1.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/auth-oauth-device": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.0.1.tgz",
+            "integrity": "sha512-yxU0rkL65QkjbqQedgVx3gmW7YM5fF+r5uaSj9tM/cQGVqloXcqP2xK90eTyYvl29arFVCW8Vz4H/t47mL0ELw==",
+            "requires": {
+                "@octokit/oauth-methods": "^4.0.0",
+                "@octokit/request": "^8.0.0",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/auth-oauth-user": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.0.1.tgz",
+            "integrity": "sha512-N94wWW09d0hleCnrO5wt5MxekatqEJ4zf+1vSe8MKMrhZ7gAXKFOKrDEZW2INltvBWJCyDUELgGRv8gfErH1Iw==",
+            "requires": {
+                "@octokit/auth-oauth-device": "^6.0.0",
+                "@octokit/oauth-methods": "^4.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/types": "^12.0.0",
+                "btoa-lite": "^1.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+        },
+        "@octokit/auth-unauthenticated": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+            "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+            "requires": {
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0"
+            }
+        },
+        "@octokit/core": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
+            "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+            "requires": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/endpoint": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
+            "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+            "requires": {
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/graphql": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+            "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+            "requires": {
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/oauth-app": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+            "integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+            "requires": {
+                "@octokit/auth-oauth-app": "^7.0.0",
+                "@octokit/auth-oauth-user": "^4.0.0",
+                "@octokit/auth-unauthenticated": "^5.0.0",
+                "@octokit/core": "^5.0.0",
+                "@octokit/oauth-authorization-url": "^6.0.2",
+                "@octokit/oauth-methods": "^4.0.0",
+                "@types/aws-lambda": "^8.10.83",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/oauth-authorization-url": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+            "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA=="
+        },
+        "@octokit/oauth-methods": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.0.1.tgz",
+            "integrity": "sha512-1NdTGCoBHyD6J0n2WGXg9+yDLZrRNZ0moTEex/LSPr49m530WNKcCfXDghofYptr3st3eTii+EHoG5k/o+vbtw==",
+            "requires": {
+                "@octokit/oauth-authorization-url": "^6.0.2",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "btoa-lite": "^1.0.0"
+            }
+        },
+        "@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+        },
+        "@octokit/plugin-paginate-graphql": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+            "integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+            "requires": {}
+        },
+        "@octokit/plugin-paginate-rest": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+            "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+            "requires": {
+                "@octokit/types": "^12.6.0"
+            }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "requires": {
+                "@octokit/types": "^12.6.0"
+            }
+        },
+        "@octokit/plugin-retry": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+            "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
+            "requires": {
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "bottleneck": "^2.15.3"
+            }
+        },
+        "@octokit/plugin-throttling": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+            "integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+            "requires": {
+                "@octokit/types": "^12.2.0",
+                "bottleneck": "^2.15.3"
+            }
+        },
+        "@octokit/request": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
+            "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+            "requires": {
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/request-error": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
+            "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+            "requires": {
+                "@octokit/types": "^12.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "requires": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "@octokit/webhooks": {
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.1.2.tgz",
+            "integrity": "sha512-+nGS3ReCByF6m+nbNB59x7Aa3CNjCCGuBLFzfkiJP1O3uVKKuJbkP4uO4t46YqH26nlugmOhqjT7nx5D0VPtdA==",
+            "requires": {
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/webhooks-methods": "^4.1.0",
+                "@octokit/webhooks-types": "7.3.2",
+                "aggregate-error": "^3.1.0"
+            }
+        },
+        "@octokit/webhooks-methods": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+            "integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ=="
+        },
+        "@octokit/webhooks-types": {
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.3.2.tgz",
+            "integrity": "sha512-JWOoOgtWTFnTSAamPXXyjTY5/apttvNxF+vPBnwdSu5cj5snrd7FO0fyw4+wTXy8fHduq626JjhO+TwCyyA6vA=="
         },
         "@peculiar/asn1-schema": {
             "version": "2.3.6",
@@ -12599,6 +14521,11 @@
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
             "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
         },
+        "@types/aws-lambda": {
+            "version": "8.10.136",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.136.tgz",
+            "integrity": "sha512-cmmgqxdVGhxYK9lZMYYXYRJk6twBo53ivtXjIUEFZxfxe4TkZTZBK3RRWrY2HjJcUIix0mdifn15yjOAat5lTA=="
+        },
         "@types/babel__core": {
             "version": "7.1.19",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -12638,6 +14565,19 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
+            }
+        },
+        "@types/btoa-lite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+            "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="
+        },
+        "@types/debug": {
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+            "requires": {
+                "@types/ms": "*"
             }
         },
         "@types/graceful-fs": {
@@ -12694,6 +14634,27 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
+        "@types/jsonwebtoken": {
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+            "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/mdast": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+            "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
+        "@types/ms": {
+            "version": "0.7.34",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+            "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+        },
         "@types/node": {
             "version": "14.14.30",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
@@ -12716,6 +14677,11 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "@types/unist": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+            "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
         },
         "@types/vscode": {
             "version": "1.71.0",
@@ -12916,7 +14882,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
             "requires": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -13020,6 +14985,11 @@
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
             }
+        },
+        "b4a": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
         },
         "babel-jest": {
             "version": "29.1.2",
@@ -13147,6 +15117,12 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
+        "bare-events": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.1.tgz",
+            "integrity": "sha512-9GYPpsPFvrWBkelIhOhTWtkeZxVxZOdb3VnFTCzlOo3OjvmTvzLoZFUT8kNFACx0vJej6QPney1Cf9BvzCNE/A==",
+            "optional": true
+        },
         "base-x": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -13164,6 +15140,11 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "bignumber.js": {
             "version": "9.1.1",
@@ -13225,6 +15206,11 @@
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
                 }
             }
+        },
+        "bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -13296,6 +15282,11 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
+        },
         "buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -13323,6 +15314,11 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "buffer-fill": {
             "version": "1.0.0",
@@ -13443,6 +15439,11 @@
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true
         },
+        "character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+        },
         "cheerio": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -13517,8 +15518,7 @@
         "clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
         },
         "cli-cursor": {
             "version": "3.1.0",
@@ -13750,6 +15750,70 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
+            }
+        },
+        "decode-named-character-reference": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+            "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+            "requires": {
+                "character-entities": "^2.0.0"
+            }
+        },
+        "decomp-tar": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/decomp-tar/-/decomp-tar-0.1.1.tgz",
+            "integrity": "sha512-+MVkfgK6GRAdwbIN/4LTpBjONYCeCvAHWyQNYZXjl1e3bPKbNHu+dL62qR5ziHcMhjCeFOGvMx1mZbfiQ6+4zg==",
+            "requires": {
+                "file-type": "^5.2.0",
+                "is-stream": "^3.0.0",
+                "tar-stream": "^3.1.6"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+                },
+                "tar-stream": {
+                    "version": "3.1.7",
+                    "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+                    "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+                    "requires": {
+                        "b4a": "^1.6.4",
+                        "fast-fifo": "^1.2.0",
+                        "streamx": "^2.15.0"
+                    }
+                }
+            }
+        },
+        "decomp-tarxz": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/decomp-tarxz/-/decomp-tarxz-0.1.1.tgz",
+            "integrity": "sha512-V6bThFjjouy/kQz6cDuf/DZnQ5eMi32bggu6rSNByNnzTll7jDygUWFDV2J3x6LUZVU4CsfpkNFHcUeGgl/SUQ==",
+            "requires": {
+                "@napi-rs/lzma": "^1.1.2",
+                "decomp-tar": "^0.1.1",
+                "file-type": "^12.3.0",
+                "get-stream": "^8.0.1",
+                "is-stream": "^3.0.0"
+            },
+            "dependencies": {
+                "file-type": {
+                    "version": "12.4.2",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+                    "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+                },
+                "get-stream": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+                    "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="
+                },
+                "is-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+                }
             }
         },
         "decompress": {
@@ -14066,6 +16130,16 @@
             "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
             "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
         },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
+        "dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+        },
         "detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -14077,6 +16151,14 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
+        },
+        "devlop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "requires": {
+                "dequal": "^2.0.0"
+            }
         },
         "dhall-to-json-cli": {
             "version": "1.7.6",
@@ -14168,6 +16250,14 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "electron-to-chromium": {
             "version": "1.4.271",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.271.tgz",
@@ -14175,9 +16265,9 @@
             "dev": true
         },
         "elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
             "requires": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -14593,6 +16683,11 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
+        "fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+        },
         "fast-glob": {
             "version": "3.2.12",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -14728,6 +16823,16 @@
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
+        "fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
         "fs-minipass": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -14797,6 +16902,11 @@
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
+        },
+        "get-east-asian-width": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA=="
         },
         "get-folder-size": {
             "version": "4.0.0",
@@ -15049,82 +17159,92 @@
             "dev": true
         },
         "ic-mops": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-0.26.3.tgz",
-            "integrity": "sha512-AQSIpU9C16IdW+0v+fN0KD5eZxjVq7oMXWYet63vwLA+v42i49Uy0sH4b1DbVPreZouGwoZmbKbBaU0feiRBnA==",
+            "version": "0.39.2",
+            "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-0.39.2.tgz",
+            "integrity": "sha512-OIwP5Zl0v2VgaUte9inrVDUL0T53SUOxpE5WEj8+RTI40MG/zGb0vrgIcNVjZM6hsmynPtfAd/O1OMaoFuz2pg==",
             "requires": {
-                "@dfinity/agent": "^0.18.1",
-                "@dfinity/candid": "^0.18.1",
-                "@dfinity/identity": "^0.18.1",
-                "@dfinity/identity-secp256k1": "^0.18.1",
-                "@dfinity/principal": "^0.18.1",
+                "@dfinity/agent": "^0.19.3",
+                "@dfinity/candid": "^0.19.3",
+                "@dfinity/identity": "^0.19.3",
+                "@dfinity/identity-secp256k1": "^0.19.3",
+                "@dfinity/principal": "^0.19.3",
                 "@iarna/toml": "^2.2.5",
+                "@noble/hashes": "1.3.2",
                 "as-table": "^1.0.55",
                 "cacheable-request": "10.2.12",
                 "camelcase": "^7.0.1",
                 "chalk": "^5.3.0",
                 "chokidar": "^3.5.3",
-                "commander": "^11.0.0",
+                "commander": "11.1.0",
                 "debounce": "^1.2.1",
+                "decomp-tarxz": "0.1.1",
                 "decompress": "^4.2.1",
                 "del": "^7.0.0",
                 "dhall-to-json-cli": "^1.7.6",
                 "eslint": "^8.45.0",
                 "execa": "7.1.1",
+                "fs-extra": "11.2.0",
                 "get-folder-size": "^4.0.0",
                 "glob": "^10.3.3",
                 "globby": "^13.2.2",
                 "got": "13.0.0",
-                "log-update": "^5.0.1",
+                "log-update": "6.0.0",
+                "markdown-table": "3.0.3",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.1.0",
                 "minimatch": "^9.0.3",
                 "ncp": "^2.0.0",
                 "node-fetch": "^3.3.2",
+                "octokit": "3.1.2",
                 "pem-file": "^1.0.1",
+                "pic-ic": "0.3.2",
                 "prompts": "^2.4.2",
                 "stream-to-promise": "^3.0.0",
+                "string-width": "7.0.0",
                 "tar": "^6.1.15"
             },
             "dependencies": {
                 "@dfinity/agent": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-                    "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.3.tgz",
+                    "integrity": "sha512-q410aNLoOA1ZkwdAMgSo6t++pjISn9TfSybRXhPRI5Ume7eG6+6qYr/rlvcXy7Nb2+Ar7LTsHNn34IULfjni7w==",
                     "requires": {
+                        "@noble/hashes": "^1.3.1",
                         "base64-arraybuffer": "^0.2.0",
                         "borc": "^2.1.1",
-                        "js-sha256": "0.9.0",
                         "simple-cbor": "^0.4.1"
                     }
                 },
                 "@dfinity/candid": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-                    "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg=="
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.3.tgz",
+                    "integrity": "sha512-yXfbLSWTeRd4G0bLLxYoDqpXH3Jim0P+1PPZOoktXNC1X1hB+ea3yrZebX75t4GVoQK7123F7mxWHiPjuV2tQQ==",
+                    "requires": {}
                 },
                 "@dfinity/identity": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.18.1.tgz",
-                    "integrity": "sha512-u8pXzjEciaLad8WykwIO4nuASr0MdJHwFjd32TKr6oquJ6caMCDj0N8vlHfoWM6oInhYIWIME4pucjAM/isP2A==",
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.3.tgz",
+                    "integrity": "sha512-6XHrkNQ8tVN6+MERyXPy+avGHTd2zoX3l47bu6gSwreDdOZQnAnXpHVzLcXhnUptkBVetcC70YQEKCmqtuLriA==",
                     "requires": {
+                        "@noble/hashes": "^1.3.1",
                         "borc": "^2.1.1",
-                        "js-sha256": "^0.9.0",
                         "tweetnacl": "^1.0.1"
                     }
                 },
                 "@dfinity/principal": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-                    "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+                    "version": "0.19.3",
+                    "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.3.tgz",
+                    "integrity": "sha512-+nixVvdGt7ECxRvLXDXsvU9q9sSPssBtDQ4bXa149SK6gcYcmZ6lfWIi3DJNqj3tGROxILVBsguel9tECappsA==",
                     "requires": {
-                        "js-sha256": "^0.9.0"
+                        "@noble/hashes": "^1.3.1"
                     }
                 },
                 "ansi-escapes": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-                    "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
+                    "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
                     "requires": {
-                        "type-fest": "^1.0.2"
+                        "type-fest": "^3.0.0"
                     }
                 },
                 "ansi-regex": {
@@ -15164,14 +17284,14 @@
                     }
                 },
                 "commander": {
-                    "version": "11.0.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-                    "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ=="
+                    "version": "11.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+                    "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
                 },
                 "emoji-regex": {
-                    "version": "9.2.2",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-                    "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+                    "version": "10.3.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+                    "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
                 },
                 "execa": {
                     "version": "7.1.1",
@@ -15230,21 +17350,29 @@
                     "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
                     "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
                 },
+                "is-fullwidth-code-point": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+                    "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+                    "requires": {
+                        "get-east-asian-width": "^1.0.0"
+                    }
+                },
                 "is-stream": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
                     "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
                 },
                 "log-update": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-                    "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
+                    "integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
                     "requires": {
-                        "ansi-escapes": "^5.0.0",
+                        "ansi-escapes": "^6.2.0",
                         "cli-cursor": "^4.0.0",
-                        "slice-ansi": "^5.0.0",
-                        "strip-ansi": "^7.0.1",
-                        "wrap-ansi": "^8.0.1"
+                        "slice-ansi": "^7.0.0",
+                        "strip-ansi": "^7.1.0",
+                        "wrap-ansi": "^9.0.0"
                     }
                 },
                 "mimic-fn": {
@@ -15281,6 +17409,14 @@
                     "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
                     "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
                 },
+                "pic-ic": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/pic-ic/-/pic-ic-0.3.2.tgz",
+                    "integrity": "sha512-4gCfsyzdiMzn/j9R73MjWIdvRJbRf+aRy+Gym/HGKJGX6hM69iI11EpHRj76Ot5io1xGlAGAZjXK6PA/7MEaKw==",
+                    "requires": {
+                        "bip39": "^3.1.0"
+                    }
+                },
                 "restore-cursor": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -15310,14 +17446,23 @@
                     "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
                     "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
                 },
-                "string-width": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-                    "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+                "slice-ansi": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+                    "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
                     "requires": {
-                        "eastasianwidth": "^0.2.0",
-                        "emoji-regex": "^9.2.2",
-                        "strip-ansi": "^7.0.1"
+                        "ansi-styles": "^6.2.1",
+                        "is-fullwidth-code-point": "^5.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz",
+                    "integrity": "sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==",
+                    "requires": {
+                        "emoji-regex": "^10.3.0",
+                        "get-east-asian-width": "^1.0.0",
+                        "strip-ansi": "^7.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -15334,18 +17479,18 @@
                     "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
                 },
                 "type-fest": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+                    "version": "3.13.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+                    "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
                 },
                 "wrap-ansi": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-                    "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+                    "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
                     "requires": {
-                        "ansi-styles": "^6.1.0",
-                        "string-width": "^5.0.1",
-                        "strip-ansi": "^7.0.1"
+                        "ansi-styles": "^6.2.1",
+                        "string-width": "^7.0.0",
+                        "strip-ansi": "^7.1.0"
                     }
                 }
             }
@@ -15406,8 +17551,7 @@
         "indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
         },
         "inflight": {
             "version": "1.0.6",
@@ -16987,6 +19131,61 @@
             "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
             "dev": true
         },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
+        "jsonwebtoken": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "requires": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+                    "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "keytar": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -17242,6 +19441,36 @@
                 "p-locate": "^4.1.0"
             }
         },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -17252,6 +19481,11 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
         },
         "log-update": {
             "version": "4.0.0",
@@ -17312,6 +19546,11 @@
                     }
                 }
             }
+        },
+        "longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
         },
         "lower-case": {
             "version": "2.0.2",
@@ -17386,6 +19625,11 @@
                 }
             }
         },
+        "markdown-table": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="
+        },
         "md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -17394,6 +19638,57 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "mdast-util-from-markdown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+            "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+            "requires": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            }
+        },
+        "mdast-util-phrasing": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "requires": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            }
+        },
+        "mdast-util-to-markdown": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+            "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+            "requires": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            }
+        },
+        "mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "requires": {
+                "@types/mdast": "^4.0.0"
             }
         },
         "mdurl": {
@@ -17417,6 +19712,217 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+        },
+        "micromark": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+            "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+            "requires": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-core-commonmark": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+            "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+            "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-factory-destination": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+            "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+            "requires": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-factory-label": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+            "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+            "requires": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-factory-space": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "requires": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-factory-title": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+            "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+            "requires": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-factory-whitespace": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+            "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+            "requires": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-util-character": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "requires": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-util-chunked": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+            "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+            "requires": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "micromark-util-classify-character": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+            "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+            "requires": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-util-combine-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+            "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+            "requires": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+            "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+            "requires": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "micromark-util-decode-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+            "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+            "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "micromark-util-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
+        },
+        "micromark-util-html-tag-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+            "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw=="
+        },
+        "micromark-util-normalize-identifier": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+            "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+            "requires": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "micromark-util-resolve-all": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+            "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+            "requires": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-util-sanitize-uri": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+            "requires": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "micromark-util-subtokenize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+            "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+            "requires": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "micromark-util-symbol": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+        },
+        "micromark-util-types": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
         },
         "micromatch": {
             "version": "4.0.5",
@@ -17611,9 +20117,9 @@
             }
         },
         "node-gyp-build": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+            "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
         },
         "node-int64": {
             "version": "0.4.0",
@@ -17769,6 +20275,23 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
             "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+        },
+        "octokit": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+            "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+            "requires": {
+                "@octokit/app": "^14.0.2",
+                "@octokit/core": "^5.0.0",
+                "@octokit/oauth-app": "^6.0.0",
+                "@octokit/plugin-paginate-graphql": "^4.0.0",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+                "@octokit/plugin-retry": "^6.0.0",
+                "@octokit/plugin-throttling": "^8.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0"
+            }
         },
         "once": {
             "version": "1.4.0",
@@ -18169,6 +20692,11 @@
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
         },
+        "queue-tick": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+        },
         "quick-lru": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -18542,6 +21070,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
             "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^6.0.0",
                 "is-fullwidth-code-point": "^4.0.0"
@@ -18550,12 +21079,14 @@
                 "ansi-styles": {
                     "version": "6.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
+                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-                    "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
+                    "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+                    "dev": true
                 }
             }
         },
@@ -18655,6 +21186,16 @@
                 "any-promise": "~1.3.0",
                 "end-of-stream": "~1.4.1",
                 "stream-to-array": "~2.3.0"
+            }
+        },
+        "streamx": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
+            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+            "requires": {
+                "bare-events": "^2.2.0",
+                "fast-fifo": "^1.1.0",
+                "queue-tick": "^1.0.1"
             }
         },
         "string_decoder": {
@@ -19098,6 +21639,60 @@
             "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
             "dev": true
         },
+        "unist-util-is": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+            "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+            "requires": {
+                "@types/unist": "^3.0.0"
+            }
+        },
+        "unist-util-stringify-position": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "requires": {
+                "@types/unist": "^3.0.0"
+            }
+        },
+        "unist-util-visit": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+            "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+            "requires": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            }
+        },
+        "unist-util-visit-parents": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+            "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+            "requires": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            }
+        },
+        "universal-github-app-jwt": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.2.tgz",
+            "integrity": "sha512-t1iB2FmLFE+yyJY9+3wMx0ejB+MQpEVkH0gQv7dR6FZyltyq+ZZO0uDpbopxhrZ3SLEO4dCEkIujOMldEQ2iOA==",
+            "requires": {
+                "@types/jsonwebtoken": "^9.0.0",
+                "jsonwebtoken": "^9.0.2"
+            }
+        },
+        "universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+        },
+        "universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        },
         "update-browserslist-db": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
@@ -19521,6 +22116,11 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+        },
+        "zwitch": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "ic-mops": "0.26.3",
                 "ic0": "0.2.7",
                 "mnemonist": "0.39.5",
-                "motoko": "3.6.13",
+                "motoko": "3.6.14",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.8.4",
                 "url-relative": "1.0.0",
@@ -8566,9 +8566,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.6.13",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.13.tgz",
-            "integrity": "sha512-HcsSeb3h/G6sw3m/uX7GKnpbzQDI0jW88h07UqcxGBS1h4cdeCDX8rYO2KupbIzzQoTr3A0MCtrVWEG8OTQTgg==",
+            "version": "3.6.14",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.14.tgz",
+            "integrity": "sha512-Ww/5J5ub9LArX9/m2FLsZ+IibpfNmPbQ+hktxiEwn8ZxHiZl7Ma1Hoo+qpB8buVqpHARgTFYgPXnbPRtCsL6Dw==",
             "dependencies": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
@@ -17511,9 +17511,9 @@
             }
         },
         "motoko": {
-            "version": "3.6.13",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.13.tgz",
-            "integrity": "sha512-HcsSeb3h/G6sw3m/uX7GKnpbzQDI0jW88h07UqcxGBS1h4cdeCDX8rYO2KupbIzzQoTr3A0MCtrVWEG8OTQTgg==",
+            "version": "3.6.14",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.6.14.tgz",
+            "integrity": "sha512-Ww/5J5ub9LArX9/m2FLsZ+IibpfNmPbQ+hktxiEwn8ZxHiZl7Ma1Hoo+qpB8buVqpHARgTFYgPXnbPRtCsL6Dw==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.16.1",
+            "version": "0.16.2",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
         "ic-mops": "0.26.3",
         "ic0": "0.2.7",
         "mnemonist": "0.39.5",
-        "motoko": "3.6.13",
+        "motoko": "3.6.14",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.8.4",
         "url-relative": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
         "change-case": "4.1.2",
         "execa": "^4.1.0",
         "fast-glob": "3.2.12",
-        "ic-mops": "0.26.3",
+        "ic-mops": "0.39.2",
         "ic0": "0.2.7",
         "mnemonist": "0.39.5",
         "motoko": "3.6.14",


### PR DESCRIPTION
Tested and appears to work with the latest version. Splitting this into a separate PR both for the changelog and so we could roll this back if needed.