### PR TITLE
Support custom dfx canister principals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.16.3",
+            "version": "0.16.4",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/dfx.ts
+++ b/src/server/dfx.ts
@@ -4,6 +4,12 @@ import { dirname } from 'path';
 interface DfxCanister {
     type?: string;
     main?: string;
+    remote?: {
+        candid?: string;
+        id?: {
+            local?: string;
+        };
+    };
 }
 
 interface DfxConfig {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -444,6 +444,22 @@ function notifyDfxChange() {
                                     const id = canister.remote?.id?.local;
                                     if (id) {
                                         aliases[name] = id;
+                                        const candidPath =
+                                            canister.remote?.candid;
+                                        if (candidPath) {
+                                            // Add Candid as virtual file in LSP directory
+                                            const candid = readFileSync(
+                                                resolve(projectDir, candidPath),
+                                                'utf8',
+                                            );
+                                            writeVirtual(
+                                                resolveVirtualPath(
+                                                    candidUri,
+                                                    `${id}.did`,
+                                                ),
+                                                candid,
+                                            );
+                                        }
                                     }
                                 }
                             },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -438,7 +438,18 @@ function notifyDfxChange() {
                                 },
                             );
                         }
+                        Object.entries(dfxConfig.canisters).forEach(
+                            ([name, canister]) => {
+                                if (!aliases.hasOwnProperty(name)) {
+                                    const id = canister.remote?.id?.local;
+                                    if (id) {
+                                        aliases[name] = id;
+                                    }
+                                }
+                            },
+                        );
                         allContexts().forEach(({ motoko }) => {
+                            console.log('Actor aliases:', aliases);
                             motoko.setAliases(
                                 resolveVirtualPath(candidUri),
                                 aliases,


### PR DESCRIPTION
This PR adds support for `"type": "custom"` canisters with explicit canister IDs. 

Because these canisters are not included in `.dfx/local/canister_ids.json` or the `.dfx/local/lsp/` directory, a special case is required for these canisters.

Although this fixes compiler errors in the [Cycles Faucet](https://github.com/dfinity-lab/cycles-faucet) codebase, additional follow-up changes to the extension and/or `dfx` may be needed to generalize this to all possible cases (e.g. deploying with a `--specified-id` flag).