### PR TITLE
Fix corner case with test file discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.16.9",
+    "version": "0.16.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.16.9",
+            "version": "0.16.10",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.16.9",
+    "version": "0.16.10",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/common/watchConfig.ts
+++ b/src/common/watchConfig.ts
@@ -1,1 +1,6 @@
 export const watchGlob = '**/*.{mo,did,json,dhall,toml}';
+
+export const ignoreGlobPatterns = [
+    '**/node_modules/**/*', // npm packages
+    '**/.vessel/.tmp/**/*', // temporary Vessel files
+];

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -45,7 +45,10 @@ import {
     TEST_FILE_REQUEST,
     TestResult,
 } from '../common/connectionTypes';
-import { watchGlob as virtualFilePattern } from '../common/watchConfig';
+import {
+    ignoreGlobPatterns,
+    watchGlob as virtualFilePattern,
+} from '../common/watchConfig';
 import icCandid from '../generated/aaaaa-aa.did';
 import { globalASTCache } from './ast';
 import {
@@ -102,11 +105,6 @@ interface MotokoSettings {
     maxNumberOfProblems: number;
     debugHover: boolean;
 }
-
-const ignoreGlobs = [
-    '**/node_modules/**/*', // npm packages
-    '**/.vessel/.tmp/**/*', // temporary Vessel files
-];
 
 const shouldHideWarnings = (uri: string) =>
     uri.includes('/.vessel/') || uri.includes('/.mops/');
@@ -246,7 +244,7 @@ function notifyPackageConfigChange(reuseCached = false) {
                     const cwd = resolveFilePath(workspaceFolder.uri);
                     const paths = glob.sync(`**/{${filenames.join(',')}}`, {
                         cwd,
-                        ignore: ignoreGlobs,
+                        ignore: ignoreGlobPatterns,
                         dot: false,
                         followSymbolicLinks: false,
                     });
@@ -686,7 +684,7 @@ function notifyWorkspace() {
         glob.sync(virtualFilePattern, {
             cwd: folderPath,
             dot: true,
-            ignore: ignoreGlobs,
+            ignore: ignoreGlobPatterns,
             followSymbolicLinks: false,
         }).forEach((relativePath) => {
             const path = join(folderPath, relativePath);


### PR DESCRIPTION
This PR fixes a `too many symbolic links encountered` error message which can prevent the extension from loading in repositories with a large number of symlinks (e.g. in a `node_modules` directory). 