### PR TITLE
Add `workflow_dispatch` for release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
     - published
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Makes it possible for us to manually trigger the "Release" workflow (consistent with other DFINITY repositories).
