### PR TITLE
Remove trailing semicolons and commas in Candid formatter

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -11,6 +11,11 @@ import { join } from 'path';
 import { getCurrentWorkspaceRootFsPath } from './utils';
 import * as motokoPlugin from 'prettier-plugin-motoko';
 
+const candidConfigOverrides: prettier.Options = {
+    semi: false,
+    trailingComma: 'none',
+};
+
 export function formatDocument(
     document: TextDocument,
     _context: ExtensionContext,
@@ -47,6 +52,9 @@ export function formatDocument(
                         ...(config || {}),
                         plugins: [motokoPlugin],
                     };
+                    if (document.fileName.endsWith('.did')) {
+                        Object.assign(prettierOptions, candidConfigOverrides);
+                    }
                     const firstLine = document.lineAt(0);
                     const lastLine = document.lineAt(document.lineCount - 1);
                     const fullTextRange = new Range(

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -11,7 +11,7 @@ import { join } from 'path';
 import { getCurrentWorkspaceRootFsPath } from './utils';
 import * as motokoPlugin from 'prettier-plugin-motoko';
 
-const candidConfigOverrides: prettier.Options = {
+const candidOptions: prettier.Options = {
     semi: false,
     trailingComma: 'none',
 };
@@ -53,7 +53,7 @@ export function formatDocument(
                         plugins: [motokoPlugin],
                     };
                     if (document.fileName.endsWith('.did')) {
-                        Object.assign(prettierOptions, candidConfigOverrides);
+                        Object.assign(prettierOptions, candidOptions);
                     }
                     const firstLine = document.lineAt(0);
                     const lastLine = document.lineAt(document.lineCount - 1);


### PR DESCRIPTION
Fixes an issue reported by @letmejustputthishere related to a trailing semicolon when specifying init args in a Candid file. 