### PR TITLE
Update `moc` to 0.14.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.17.4",
+    "version": "0.18.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.17.4",
+            "version": "0.18.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.17.4",
+    "version": "0.18.0",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {


### PR DESCRIPTION
Since this release includes significant changes (#347), the plan is to wait until early next week to deploy so that we can more quickly make follow-up changes if needed.