### PR TITLE
fix: trim trailing whitespace from Motoko code snippets

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1481,7 +1481,7 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                 const isSameLine = node.start[0] === node.end[0];
 
                 const codeSnippet = (source: string) =>
-                    `\`\`\`motoko\n${source}\n\`\`\``;
+                    `\`\`\`motoko\n${source.trimEnd()}\n\`\`\``;
                 const source = (
                     isSameLine
                         ? startLine.substring(node.start[1], node.end[1])

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -33,7 +33,7 @@ describe('cache', () => {
         });
         expect(hover.contents).toStrictEqual({
             kind: 'markdown',
-            value: '```motoko\nmodule { top : { foo : () -> () } }\n\n```',
+            value: '```motoko\nmodule { top : { foo : () -> () } }\n```',
         });
     });
 
@@ -60,7 +60,7 @@ describe('cache', () => {
         });
         expect(hover.contents).toStrictEqual({
             kind: 'markdown',
-            value: '```motoko\nmodule { top : { foo : () -> () } }\n\n```',
+            value: '```motoko\nmodule { top : { foo : () -> () } }\n```',
         });
     });
 
@@ -101,7 +101,7 @@ describe('cache', () => {
         });
         expect(hover.contents).toStrictEqual({
             kind: 'markdown',
-            value: '```motoko\nmodule { top : { foo : () -> Nat } }\n\n```',
+            value: '```motoko\nmodule { top : { foo : () -> Nat } }\n```',
         });
     });
 
@@ -135,7 +135,7 @@ describe('cache', () => {
         });
         expect(hover.contents).toStrictEqual({
             kind: 'markdown',
-            value: '```motoko\n{ bar : () -> (); foo : Nat }\n\n```',
+            value: '```motoko\n{ bar : () -> (); foo : Nat }\n```',
         });
     });
 
@@ -186,7 +186,7 @@ describe('cache', () => {
         });
         expect(hover0.contents).toStrictEqual({
             kind: 'markdown',
-            value: '```motoko\nInt\n\n```',
+            value: '```motoko\nInt\n```',
         });
         expect(hover1).toStrictEqual(hover0);
     });


### PR DESCRIPTION
When using the language server included in vscode-motoko with Zed, distracting blank lines are displayed when the hint displayed on hover ends with a code snippet.
To avoid this, `trimEnd()` has been added within `codeSnippet`.