### PR TITLE
Replace `motoko.deployPlayground` command with `motoko.deployTemporary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Below are the default key bindings for commonly used features supported in the e
 ## Commands
 
 - `Motoko: Restart language server`: Starts (or restarts) the language server
-- `Motoko: Deploy (20 minutes)`: Temporarily deploys the currently open file to the Internet Computer via [Motoko Playground](https://play.motoko.org/)
+- `Motoko: Deploy (20 minutes)`: Temporarily deploys the currently open file to the Internet Computer.
 - `Motoko: Import Mops Package...`: Search, install and import a package from [Mops](https://mops.one)
 
-[![Motoko Playground deployment](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/deploy.png)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
+[![Temporary deployment](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/deploy.png)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Below are the default key bindings for commonly used features supported in the e
 ## Commands
 
 - `Motoko: Restart language server`: Starts (or restarts) the language server
-- `Motoko: Deploy (20 minutes)`: Temporarily deploys the currently open file to the Internet Computer.
+- `Motoko: Deploy (20 minutes)`: Temporarily deploys the currently open file to the Internet Computer
 - `Motoko: Import Mops Package...`: Search, install and import a package from [Mops](https://mops.one)
 
 [![Temporary deployment](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/deploy.png)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
                 "title": "Motoko: Restart language server"
             },
             {
-                "command": "motoko.deployPlayground",
+                "command": "motoko.deployTemporary",
                 "title": "Motoko: Deploy (20 minutes)"
             },
             {
@@ -143,14 +143,14 @@
             "explorer/context": [
                 {
                     "when": "resourceLangId == motoko",
-                    "command": "motoko.deployPlayground",
+                    "command": "motoko.deployTemporary",
                     "group": "2_main"
                 }
             ],
             "editor/context": [
                 {
                     "when": "resourceLangId == motoko",
-                    "command": "motoko.deployPlayground",
+                    "command": "motoko.deployTemporary",
                     "group": "2_main"
                 }
             ]

--- a/src/common/connectionTypes.ts
+++ b/src/common/connectionTypes.ts
@@ -14,11 +14,16 @@ export interface TestResult {
     stderr: string;
 }
 
-export const DEPLOY_PLAYGROUND = new RequestType<
+export const DEPLOY_TEMPORARY = new RequestType<
     DeployParams,
     DeployResult,
     any
->('vscode-motoko/deploy-playground');
+>('vscode-motoko/deploy-temporary');
+
+export const DEPLOY_TEMPORARY_MESSAGE =
+    new NotificationType<NotifyDeployParams>(
+        'vscode-motoko/notify-deploy-temporary',
+    );
 
 export interface DeployParams {
     uri: string;
@@ -27,11 +32,6 @@ export interface DeployParams {
 export interface DeployResult {
     canisterId: string;
 }
-
-export const DEPLOY_PLAYGROUND_MESSAGE =
-    new NotificationType<NotifyDeployParams>(
-        'vscode-motoko/notify-deploy-playground',
-    );
 
 export interface NotifyDeployParams {
     message: string;

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -72,7 +72,7 @@ function requestMotokoInstance(uri: string, version: Version): Motoko {
             motoko.setTypecheckerCombineSrcs(true);
         }
     }
-    // Required for deploying to Motoko Playground
+    // Required for temporary deployment (originally Motoko Playground)
     motoko.setPublicMetadata([
         'candid:service',
         'candid:args',

--- a/src/server/deployer.ts
+++ b/src/server/deployer.ts
@@ -28,7 +28,7 @@ interface ProfilingConfig {
     page_limit: [] | [number];
 }
 
-const playground = ic('mwrha-maaaa-aaaab-qabqq-cai');
+const deployer = ic('mwrha-maaaa-aaaab-qabqq-cai');
 
 const origin = { origin: 'vscode', tags: [] };
 
@@ -38,7 +38,7 @@ const currentCanisterTimeoutMap = new Map<
     ReturnType<typeof setTimeout>
 >();
 
-export async function deployPlayground(
+export async function deployTemporary(
     { uri }: DeployParams,
     notify: (message: string) => void,
 ): Promise<DeployResult> {
@@ -134,7 +134,7 @@ export async function deployPlayground(
     async function createCanister(): Promise<CanisterInfo> {
         const nonce = pow();
         notify('Creating new canister...');
-        const info: CanisterInfo = await playground.call(
+        const info: CanisterInfo = await deployer.call(
             'getCanisterId',
             nonce,
             origin,
@@ -170,7 +170,7 @@ export async function deployPlayground(
             is_whitelisted: false,
             origin,
         };
-        const newInfo: CanisterInfo = await playground.call(
+        const newInfo: CanisterInfo = await deployer.call(
             'installCode',
             canisterInfo,
             installArgs,

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -37,8 +37,8 @@ import {
 } from 'vscode-languageserver/node';
 import { URI } from 'vscode-uri';
 import {
-    DEPLOY_PLAYGROUND,
-    DEPLOY_PLAYGROUND_MESSAGE,
+    DEPLOY_TEMPORARY,
+    DEPLOY_TEMPORARY_MESSAGE,
     ERROR_MESSAGE,
     IMPORT_MOPS_PACKAGE,
     TEST_FILE_REQUEST,
@@ -74,7 +74,7 @@ import {
     searchObject,
     sameDefinition,
 } from './navigation';
-import { deployPlayground } from './playground';
+import { deployTemporary } from './deployer';
 import {
     Class,
     Field,
@@ -1859,11 +1859,11 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         },
     );
 
-    // Deploy to Motoko Playground
-    connection.onRequest(DEPLOY_PLAYGROUND, async (params) => {
+    // Temporary canister deployment
+    connection.onRequest(DEPLOY_TEMPORARY, async (params) => {
         const notify = (message: string) => {
             console.log(message);
-            connection.sendNotification(DEPLOY_PLAYGROUND_MESSAGE, { message });
+            connection.sendNotification(DEPLOY_TEMPORARY_MESSAGE, { message });
         };
         try {
             if (!isWorkspaceReady) {
@@ -1872,7 +1872,7 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                     await new Promise((resolve) => setTimeout(resolve, 200));
                 }
             }
-            return deployPlayground(params, notify);
+            return deployTemporary(params, notify);
         } catch (err) {
             console.error(err);
             throw err;


### PR DESCRIPTION
This PR removes references to Motoko Playground in favor of referring to this feature in a more generic way.