### PR TITLE
[Chore] Fix go-to-definition for var

### DIFF
--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -515,12 +515,12 @@ function searchDeclaration(
                 }
             );
         }) ||
-        matchNode(dec, 'VarD', (pat: Node, body: Node) => {
-            const [name, varNode] = findNameInPattern(search, pat) || [];
-            return varNode && name === search.name
+        matchNode(dec, 'VarD', (id: Node, body: Node) => {
+            const name = getIdName(id);
+            return name === search.name
                 ? {
                       uri: reference.uri,
-                      cursor: varNode,
+                      cursor: id,
                       body,
                       name,
                   }

--- a/src/server/test/definition.spec.ts
+++ b/src/server/test/definition.spec.ts
@@ -206,4 +206,10 @@ describe('go to definition', () => {
             );
         }
     }, 20000);
+
+    test('Can find definition for var', () =>
+        testDefinition(
+            location('var.mo', 4, 8, 9), // x
+            [location('var.mo', 1, 8, 9)], // definition of x
+        ));
 });

--- a/test/definition/var.mo
+++ b/test/definition/var.mo
@@ -1,0 +1,7 @@
+actor {
+    var x : Int = 42;
+
+    public func test() : async Int {
+        x
+    };
+};


### PR DESCRIPTION
Problem: Our work on Motoko broke go-to-definition for `var` declarations.

Solution: Fix `searchDeclaration` to properly handle ID in var declarations. Add a regression test.