### PR TITLE
Format with 2 spaces by default

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -19,7 +19,7 @@ const candidOptions: prettier.Options = {
 export function formatDocument(
     document: TextDocument,
     _context: ExtensionContext,
-    options: FormattingOptions,
+    _options: FormattingOptions,
 ): TextEdit[] {
     try {
         const formatter = workspace
@@ -39,16 +39,13 @@ export function formatDocument(
                     const source = document.getText();
 
                     const config = prettier.resolveConfig.sync(
-                        document.uri.fsPath /* , options */,
+                        document.uri.fsPath,
                     );
                     if (config !== null) {
                         prettier.clearConfigCache();
                     }
                     const prettierOptions: prettier.Options = {
                         filepath: document.fileName,
-                        // pluginSearchDirs: [join(rootPath, 'node_modules')],
-                        tabWidth: options.tabSize,
-                        useTabs: !options.insertSpaces,
                         ...(config || {}),
                         plugins: [motokoPlugin],
                     };


### PR DESCRIPTION
Modifies the built-in VS Code formatter to use 2 spaces by default as suggested in [this forum topic](https://forum.dfinity.org/t/motoko-indentation-consistency-should-the-prettier-plugin-enforce-2-spaces/53333). 

It's possible to override the default indentation by creating a [`.prettierrc`](https://prettier.io/docs/configuration) file and specifying `tabWidth` (or even `useTabs` if preferred).
