### PR TITLE
Update `moc` to 0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.18.4",
+    "version": "0.18.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.18.4",
+            "version": "0.18.5",
             "hasInstallScript": true,
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "ic-mops": "0.45.3",
                 "ic0": "0.3.1",
                 "mnemonist": "0.39.5",
-                "motoko": "3.13.4",
+                "motoko": "3.14.0",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.10.5",
                 "semver": "7.6.3",
@@ -11734,9 +11734,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.13.4",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.13.4.tgz",
-            "integrity": "sha512-tmFrUdqP4cPSxSAw601DqcJlJlRghgMoqAvYimW5yLvIzNFC0b8oV9iINZanyOOnwVyGQBJGhmbnX7GYM9AwTg==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.14.0.tgz",
+            "integrity": "sha512-4wXHIGWkhT6Xz8yDlm7ujDjswisPspLa5V4IalrnfT9u9MWeztKsjamfNxK4MnLmw4WI7NL3Hfiukcb25U4mvQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",
@@ -22760,9 +22760,9 @@
             }
         },
         "motoko": {
-            "version": "3.13.4",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.13.4.tgz",
-            "integrity": "sha512-tmFrUdqP4cPSxSAw601DqcJlJlRghgMoqAvYimW5yLvIzNFC0b8oV9iINZanyOOnwVyGQBJGhmbnX7GYM9AwTg==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.14.0.tgz",
+            "integrity": "sha512-4wXHIGWkhT6Xz8yDlm7ujDjswisPspLa5V4IalrnfT9u9MWeztKsjamfNxK4MnLmw4WI7NL3Hfiukcb25U4mvQ==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
         "ic-mops": "0.45.3",
         "ic0": "0.3.1",
         "mnemonist": "0.39.5",
-        "motoko": "3.13.4",
+        "motoko": "3.14.0",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.10.5",
         "semver": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.18.4",
+    "version": "0.18.5",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/dfinity/vscode-motoko",
     "engines": {

--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -331,9 +331,9 @@ export function followImport(
     }
     // Find the relevant field name
     const field = matchNode(
-        reference.node.parent?.parent,
-        'ObjP',
-        () => reference.node.parent?.name,
+        reference.node.parent,
+        'ValPF',
+        (name: string) => name,
     );
     // Follow the module import
     return matchNode(importNode, 'ImportE', (path: string) => {


### PR DESCRIPTION
Resolves https://github.com/dfinity/vscode-motoko/issues/376.

Because Motoko 0.15.1 uses a new `ValPF` AST node for object pattern fields, I updated the navigation logic accordingly.