### PR TITLE
Add `core` package to default compile environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "ic-mops": "0.45.3",
                 "ic0": "0.3.1",
                 "mnemonist": "0.39.5",
-                "motoko": "3.13.4",
+                "motoko": "3.14.0",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.10.5",
                 "semver": "7.6.3",
@@ -11734,9 +11734,9 @@
             }
         },
         "node_modules/motoko": {
-            "version": "3.13.4",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.13.4.tgz",
-            "integrity": "sha512-tmFrUdqP4cPSxSAw601DqcJlJlRghgMoqAvYimW5yLvIzNFC0b8oV9iINZanyOOnwVyGQBJGhmbnX7GYM9AwTg==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.14.0.tgz",
+            "integrity": "sha512-4wXHIGWkhT6Xz8yDlm7ujDjswisPspLa5V4IalrnfT9u9MWeztKsjamfNxK4MnLmw4WI7NL3Hfiukcb25U4mvQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",
@@ -22760,9 +22760,9 @@
             }
         },
         "motoko": {
-            "version": "3.13.4",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.13.4.tgz",
-            "integrity": "sha512-tmFrUdqP4cPSxSAw601DqcJlJlRghgMoqAvYimW5yLvIzNFC0b8oV9iINZanyOOnwVyGQBJGhmbnX7GYM9AwTg==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.14.0.tgz",
+            "integrity": "sha512-4wXHIGWkhT6Xz8yDlm7ujDjswisPspLa5V4IalrnfT9u9MWeztKsjamfNxK4MnLmw4WI7NL3Hfiukcb25U4mvQ==",
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
         "ic-mops": "0.45.3",
         "ic0": "0.3.1",
         "mnemonist": "0.39.5",
-        "motoko": "3.13.4",
+        "motoko": "3.14.0",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.10.5",
         "semver": "7.6.3",

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,8 +1,8 @@
 import { type Motoko } from 'motoko/lib';
-import * as baseLibrary from 'motoko/packages/latest/base.json';
-import ImportResolver from './imports';
+import * as basePackage from 'motoko/packages/latest/base.json';
+import * as corePackage from 'motoko/packages/latest/core.json';
 import AstResolver from './ast';
-import { join } from 'path';
+import ImportResolver from './imports';
 
 type Version = string | undefined; // `undefined` refers to latest version
 
@@ -60,17 +60,8 @@ function requestMotokoInstance(uri: string, version: Version): Motoko {
                 delete require.cache[key];
             }
         });
-        // TODO: download `moc.js` versions from GitHub releases
-        if (version === '0.10.4') {
-            const compiler = require(join(
-                __dirname,
-                '/compiler/moc-' + version,
-            )).Motoko;
-            motoko = require('motoko/lib').default(compiler);
-        } else {
-            motoko = require(motokoPath).default;
-            motoko.setTypecheckerCombineSrcs(true);
-        }
+        motoko = require(motokoPath).default;
+        motoko.setTypecheckerCombineSrcs(true);
     }
     // Required for temporary deployment (originally Motoko Playground)
     motoko.setPublicMetadata([
@@ -78,7 +69,8 @@ function requestMotokoInstance(uri: string, version: Version): Motoko {
         'candid:args',
         'motoko:stable-types',
     ]);
-    motoko.loadPackage(baseLibrary);
+    motoko.loadPackage(basePackage);
+    motoko.loadPackage(corePackage);
     return motoko;
 }
 

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync } from 'fs';
 import { add as mopsAdd } from 'ic-mops/commands/add';
 import { AST, Node } from 'motoko/lib/ast';
 import { keywords } from 'motoko/lib/keywords';
-import * as baseLibrary from 'motoko/packages/latest/base.json';
+import * as corePackage from 'motoko/packages/latest/core.json';
 import { join, resolve } from 'path';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
@@ -375,19 +375,14 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                     }),
                 );
 
-                // Add base library autocompletions
+                // Add core package autocompletions
                 // TODO: possibly refactor into `context.ts`
-                Object.entries(baseLibrary.files).forEach(
+                Object.entries(corePackage.files).forEach(
                     ([path, { content }]: [string, { content: string }]) => {
                         writeVirtual(
-                            resolveVirtualPath(`mo:base/${path}`),
+                            resolveVirtualPath(`mo:core/${path}`),
                             content,
                         );
-                    },
-                );
-                Object.entries(baseLibrary.files).forEach(
-                    ([path, { content }]: [string, { content: string }]) => {
-                        notifyWriteUri(`mo:base/${path}`, content);
                     },
                 );
 


### PR DESCRIPTION
This PR adds `core` in addition to `base` in the default compile environment and switches to `mo:core/*` completions instead of `mo:base/*`.