### PR TITLE
Deactivate color decorators for Motoko/Candid files

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,14 @@
                 }
             }
         },
+        "configurationDefaults": {
+            "[motoko]": {
+                "editor.colorDecorators": false
+            },
+            "[candid]": {
+                "editor.colorDecorators": false
+            }
+        },
         "commands": [
             {
                 "command": "motoko.startService",


### PR DESCRIPTION
Fixes a bug related to VS Code interpreting some variants as hexadecimal colors:

<img width="359" height="174" alt="image" src="https://github.com/user-attachments/assets/cf979693-0285-4b8e-bbb6-0a3ad8651c29" />