### PR TITLE
Add file watcher for external files on server init

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -17,6 +17,7 @@ import {
     CompletionList,
     Diagnostic,
     DiagnosticSeverity,
+    DidChangeWatchedFilesNotification,
     DocumentSymbol,
     FileChangeType,
     InitializeResult,
@@ -655,6 +656,9 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
     });
 
     connection.onInitialized(() => {
+        connection.client.register(DidChangeWatchedFilesNotification.type, {
+            watchers: [{ globPattern: virtualFilePattern }],
+        });
         connection.workspace?.onDidChangeWorkspaceFolders((event) => {
             const folders = workspaceFolders;
             if (!folders) {


### PR DESCRIPTION
For Zed, which cannot set “watchedFiles” on the client side, this adds them during server initialization.　

This will enable the server to respond to changes in files like `mops.toml`.

It has no impact on VS Code.